### PR TITLE
Fix wool touches

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/wools/WoolObjective.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/wools/WoolObjective.java
@@ -104,27 +104,6 @@ public class WoolObjective implements GameObjective {
     }
 
     @EventHandler
-    public void onWoolPickup(PlayerPickupItemEvent event) {
-        Player player = event.getPlayer();
-        if (!this.complete) {
-            try {
-                if (event.getItem().getItemStack().getType() == Material.WOOL && event.getItem().getItemStack().getData().getData() == color.getData()) {
-                    if (TeamUtils.getTeamByPlayer(player) == team) {
-                        if (!this.playersTouched.contains(player.getUniqueId())) {
-                            this.playersTouched.add(player.getUniqueId());
-                        }
-                        boolean oldState = this.touched;
-                        this.touched = true;
-                        ObjectiveTouchEvent touchEvent = new ObjectiveTouchEvent(this, player, !oldState);
-                        Bukkit.getServer().getPluginManager().callEvent(touchEvent);
-                    }
-                }
-            } catch (NullPointerException e) {
-            }
-        }
-    }
-
-    @EventHandler
     public void onWoolPickup(InventoryClickEvent event) {
         Player player = (Player) event.getWhoClicked();
         if (!this.complete) {
@@ -138,6 +117,29 @@ public class WoolObjective implements GameObjective {
                         this.touched = true;
                         ObjectiveTouchEvent touchEvent = new ObjectiveTouchEvent(this, player, !oldState);
                         Bukkit.getServer().getPluginManager().callEvent(touchEvent);
+                        Bukkit.broadcastMessage(team.getColor() + player.getDisplayName() + ChatColor.GRAY + " Picked up " + StringUtils.convertDyeColorToChatColor(color) + getName().toUpperCase());
+                    }
+                }
+            } catch (NullPointerException e) {
+            }
+        }
+    }
+
+    @EventHandler
+    public void onWoolPickup(PlayerPickupItemEvent event) {
+        Player player = (Player) event.getPlayer();
+        if (!this.complete) {
+            try {
+                if (event.getItem().getItemStack().getType() == Material.WOOL && event.getItem().getItemStack().getData().getData() == color.getData()) {
+                    if (TeamUtils.getTeamByPlayer(player) == team) {
+                        if (!this.playersTouched.contains(player.getUniqueId())) {
+                            this.playersTouched.add(player.getUniqueId());
+                        }
+                        boolean oldState = this.touched;
+                        this.touched = true;
+                        ObjectiveTouchEvent touchEvent = new ObjectiveTouchEvent(this, player, !oldState);
+                        Bukkit.getServer().getPluginManager().callEvent(touchEvent);
+                        Bukkit.broadcastMessage(team.getColor() + player.getDisplayName() + ChatColor.GRAY + " Picked up " + StringUtils.convertDyeColorToChatColor(color) + getName().toUpperCase());
                     }
                 }
             } catch (NullPointerException e) {


### PR DESCRIPTION
Previously there were two `onWoolPickup` events It also only would register when you picked it up from an inventory, now it registers the pick up even if you picked it up from the ground. I also broadcasted the wool touch.

the wool touches should be broadcasted to only players on the team and right now I don't see where you are tracking who is on what team, so if you are let me know and ill start work on team chat 