### PR TITLE
Allow users to display map.xml errors

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/rotation/Rotation.java
+++ b/src/main/java/in/twizmwaz/cardinal/rotation/Rotation.java
@@ -79,7 +79,6 @@ public class Rotation {
                 		Bukkit.getLogger().log(Level.INFO, "Showing error, this can be disabled in the config: ");
                 		e.printStackTrace();
                 	}
-                 }
                 }
             }
         }

--- a/src/main/java/in/twizmwaz/cardinal/rotation/Rotation.java
+++ b/src/main/java/in/twizmwaz/cardinal/rotation/Rotation.java
@@ -75,6 +75,11 @@ public class Rotation {
                     loaded.add(new LoadedMap(name, version, objective, authors, contributors, rules, maxPlayers, map));
                 } catch (Exception e) {
                     Bukkit.getLogger().log(Level.WARNING, "Failed to load map at " + map.getAbsolutePath());
+                    if (Cardinal.getInstance().getConfig().getBoolean("displayMapLoadErrors")) {
+                		Bukkit.getLogger().log(Level.INFO, "Showing error, this can be disabled in the config: ");
+                		e.printStackTrace();
+                	}
+                 }
                 }
             }
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,7 @@
 repo: maps
 rotation: rotation.txt
 deleteMatches: true
+displayMapLoadErrors: false
 custom-motd: true
 worldEditPermissions: true
 permissions:


### PR DESCRIPTION
Allows users to display map.xml errors, disabled by default.