### PR TITLE
Add attributes support

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/teamManager/TeamManagerModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/teamManager/TeamManagerModule.java
@@ -16,6 +16,8 @@ import in.twizmwaz.cardinal.util.TeamUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import org.bukkit.craftbukkit.v1_8_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_8_R1.inventory.CraftInventoryPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -24,8 +26,6 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.BookMeta;
-import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.Arrays;
 import java.util.Locale;
@@ -101,7 +101,13 @@ public class TeamManagerModule implements Module {
                 team.remove(player);
             }
         }
+        this.clearHeldAttribute(player);
         Bukkit.getServer().getPluginManager().callEvent(new ScoreboardUpdateEvent());
+    }
+
+    private void clearHeldAttribute(Player player) {
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        craftPlayer.getHandle().getAttributeMap().a(((CraftInventoryPlayer) craftPlayer.getInventory()).getInventory().getItemInHand().B());
     }
 
 }

--- a/src/main/java/in/twizmwaz/cardinal/util/AttributeModifier.java
+++ b/src/main/java/in/twizmwaz/cardinal/util/AttributeModifier.java
@@ -1,0 +1,39 @@
+package in.twizmwaz.cardinal.util;
+
+public class AttributeModifier {
+
+    private AttributeType attributeType;
+    private double value;
+    private String operation;
+
+    public AttributeModifier(AttributeType attributeType, double value, String operation) {
+        this.attributeType = attributeType;
+        this.value = value;
+        this.operation = operation;
+
+    }
+
+    public AttributeType getAttributeType() {
+        return attributeType;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+
+    public int getOperationValue() {
+        if (this.operation.equalsIgnoreCase("add")) {
+            return 0;
+        } else if (this.operation.equalsIgnoreCase("base")) {
+            return 1;
+        } else if (this.operation.equalsIgnoreCase("multiple")) {
+            return 2;
+        }
+        return 0;
+    }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/util/AttributeType.java
+++ b/src/main/java/in/twizmwaz/cardinal/util/AttributeType.java
@@ -1,0 +1,49 @@
+package in.twizmwaz.cardinal.util;
+
+import java.util.UUID;
+
+public enum AttributeType {
+
+    GENERIC_MAX_HEALTH("generic.maxHealth", 0, Integer.MAX_VALUE),
+    GENERIC_FOLLOW_RANGE("generic.followRange", 0, 2048),
+    GENERIC_KNOCKBACK_RESISTANCE("generic.knockbackResistance", 0, 1),
+    GENERIC_MOVEMENT_SPEED("generic.movementSpeed", 0, Double.MAX_VALUE),
+    GENERIC_ATTACK_DAMAGE("generic.attackDamage", 0, Double.MAX_VALUE),
+
+    HORSE_JUMP_STRENGTH("horse.jumpStrength", 0, 2);
+
+    private String name;
+    private double minValue;
+    private double maxValue;
+
+    public static UUID modifierUUID = UUID.fromString("CB3F55D3-645C-4F38-A497-9C13A33DB5CF");
+
+    AttributeType(String name, double minValue, double maxValue) {
+        this.name = name;
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+    }
+
+    public static AttributeType fromName(String name) {
+        for (AttributeType type: AttributeType.values()) {
+            System.out.println("Type: " + type);
+            if (type.getName().equalsIgnoreCase(name)) {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public double getMinValue() {
+        return minValue;
+    }
+
+    public double getMaxValue() {
+        return maxValue;
+    }
+
+}


### PR DESCRIPTION
This PR adds support for adding [attributes](https://docs.oc.tc/reference/attributes) to Item elements in `map.xml`.

Because there's no API in Bukkit for accessing attributes, it's necessary to access NMS to add attributes.