### PR TITLE
Fix attribute support

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/teamManager/TeamManagerModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/teamManager/TeamManagerModule.java
@@ -107,7 +107,9 @@ public class TeamManagerModule implements Module {
 
     private void clearHeldAttribute(Player player) {
         CraftPlayer craftPlayer = (CraftPlayer) player;
-        craftPlayer.getHandle().getAttributeMap().a(((CraftInventoryPlayer) craftPlayer.getInventory()).getInventory().getItemInHand().B());
+        if (player.getInventory().getItemInHand() != null && player.getInventory().getItemInHand().getType().equals(Material.AIR)) {
+            craftPlayer.getHandle().getAttributeMap().a(((CraftInventoryPlayer) craftPlayer.getInventory()).getInventory().getItemInHand().B());
+        }
     }
 
 }

--- a/src/main/java/in/twizmwaz/cardinal/util/AttributeType.java
+++ b/src/main/java/in/twizmwaz/cardinal/util/AttributeType.java
@@ -26,7 +26,6 @@ public enum AttributeType {
 
     public static AttributeType fromName(String name) {
         for (AttributeType type: AttributeType.values()) {
-            System.out.println("Type: " + type);
             if (type.getName().equalsIgnoreCase(name)) {
                 return type;
             }

--- a/src/main/java/in/twizmwaz/cardinal/util/ParseUtils.java
+++ b/src/main/java/in/twizmwaz/cardinal/util/ParseUtils.java
@@ -82,7 +82,6 @@ public class ParseUtils {
     }
 
     private static ItemStack setAttributes(ItemStack itemStack, String attributes) {
-        System.out.println("Parsing attributes");
         net.minecraft.server.v1_8_R1.ItemStack nmsStack = CraftItemStack.asNMSCopy(itemStack);
         if (nmsStack.getTag() == null) {
             nmsStack.setTag(new NBTTagCompound());


### PR DESCRIPTION
This PR removes some debugging prints (oops), and checks the player's held item for `null` before getting its attribute map.