### PR TITLE
Add Tutorial support

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/ModuleFactory.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/ModuleFactory.java
@@ -67,6 +67,7 @@ import in.twizmwaz.cardinal.module.modules.tntDefuse.TntDefuseBuilder;
 import in.twizmwaz.cardinal.module.modules.tntTracker.TntTrackerBuilder;
 import in.twizmwaz.cardinal.module.modules.toolRepair.ToolRepairBuilder;
 import in.twizmwaz.cardinal.module.modules.tracker.TrackerBuilder;
+import in.twizmwaz.cardinal.module.modules.tutorial.TutorialBuilder;
 import in.twizmwaz.cardinal.module.modules.visibility.VisibilityBuilder;
 import in.twizmwaz.cardinal.module.modules.wools.WoolObjectiveBuilder;
 import in.twizmwaz.cardinal.module.modules.worldFreeze.WorldFreezeBuilder;
@@ -150,7 +151,8 @@ public class ModuleFactory {
             HeaderModuleBuilder.class,
             CycleTimerBuilder.class,
             TimeLimitBuilder.class,
-            PlayableBuilder.class
+            PlayableBuilder.class,
+            TutorialBuilder.class
     };
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/observers/ObserverModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/observers/ObserverModule.java
@@ -1,5 +1,6 @@
 package in.twizmwaz.cardinal.module.modules.observers;
 
+import in.twizmwaz.cardinal.module.modules.tutorial.Tutorial;
 import in.twizmwaz.cardinal.util.ItemUtils;
 import org.bukkit.ChatColor;
 import in.twizmwaz.cardinal.GameHandler;
@@ -65,9 +66,10 @@ public class ObserverModule implements Module {
         player.getInventory().setItem(0, new ItemStack(Material.COMPASS));
         ItemStack howTo = ItemUtils.createBook(Material.WRITTEN_BOOK, 1, ChatColor.AQUA.toString() + ChatColor.BOLD + "Coming Soon", ChatColor.GOLD + "CardinalPGM");
         player.getInventory().setItem(1, howTo);
+        player.getInventory().setItem(3, Tutorial.getEmerald(player));
         if (player.hasPermission("tnt.defuse")) {
             ItemStack shears = ItemUtils.createItem(Material.SHEARS, 1, (short)0, ChatColor.RED + new LocalizedChatMessage(ChatConstant.UI_TNT_DEFUSER).getMessage(player.getLocale()));
-            player.getInventory().setItem(4, shears);
+            player.getInventory().setItem(5, shears);
         }
     }
 

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/respawn/RespawnModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/respawn/RespawnModule.java
@@ -14,6 +14,7 @@ import in.twizmwaz.cardinal.module.ModuleCollection;
 import in.twizmwaz.cardinal.module.modules.classModule.ClassModule;
 import in.twizmwaz.cardinal.module.modules.spawn.SpawnModule;
 import in.twizmwaz.cardinal.module.modules.team.TeamModule;
+import in.twizmwaz.cardinal.module.modules.tutorial.Tutorial;
 import in.twizmwaz.cardinal.util.ItemUtils;
 import in.twizmwaz.cardinal.util.PlayerUtils;
 import in.twizmwaz.cardinal.util.TeamUtils;
@@ -115,7 +116,7 @@ public class RespawnModule implements Module {
                 }
                 if (player.hasPermission("tnt.defuse")) {
                     ItemStack shears = ItemUtils.createItem(Material.SHEARS, 1, (short) 0, ChatColor.RED + new LocalizedChatMessage(ChatConstant.UI_TNT_DEFUSER).getMessage(player.getLocale()));
-                    player.getInventory().setItem(4, shears);
+                    player.getInventory().setItem(5, shears);
                 }
                 player.teleport(chosen.getLocation());
             }
@@ -165,9 +166,10 @@ public class RespawnModule implements Module {
                             Arrays.asList(ChatColor.DARK_PURPLE + new LocalizedChatMessage(ChatConstant.UI_TEAM_JOIN_TIP).getMessage(player.getLocale())));
                     player.getInventory().setItem(2, picker);
                 }
+                player.getInventory().setItem(3, Tutorial.getEmerald(player));
                 if (player.hasPermission("tnt.defuse")) {
                     ItemStack shears = ItemUtils.createItem(Material.SHEARS, 1, (short) 0, ChatColor.RED + new LocalizedChatMessage(ChatConstant.UI_TNT_DEFUSER).getMessage(player.getLocale()));
-                    player.getInventory().setItem(4, shears);
+                    player.getInventory().setItem(5, shears);
                 }
                 player.teleport(chosen.getLocation());
             }

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/teamManager/TeamManagerModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/teamManager/TeamManagerModule.java
@@ -1,5 +1,6 @@
 package in.twizmwaz.cardinal.module.modules.teamManager;
 
+import com.google.common.collect.Multimap;
 import in.twizmwaz.cardinal.GameHandler;
 import in.twizmwaz.cardinal.chat.ChatConstant;
 import in.twizmwaz.cardinal.chat.LocalizedChatMessage;
@@ -10,6 +11,7 @@ import in.twizmwaz.cardinal.match.MatchState;
 import in.twizmwaz.cardinal.module.Module;
 import in.twizmwaz.cardinal.module.modules.classModule.ClassModule;
 import in.twizmwaz.cardinal.module.modules.team.TeamModule;
+import in.twizmwaz.cardinal.module.modules.tutorial.Tutorial;
 import in.twizmwaz.cardinal.util.ItemUtils;
 import in.twizmwaz.cardinal.util.PlayerUtils;
 import in.twizmwaz.cardinal.util.TeamUtils;
@@ -57,9 +59,10 @@ public class TeamManagerModule implements Module {
                     Arrays.asList(ChatColor.DARK_PURPLE + new LocalizedChatMessage(ChatConstant.UI_TEAM_JOIN_TIP).getMessage(player.getLocale())));
             player.getInventory().setItem(2, picker);
         }
+        player.getInventory().setItem(3, Tutorial.getEmerald(player));
         if (player.hasPermission("tnt.defuse")) {
             ItemStack shears = ItemUtils.createItem(Material.SHEARS, 1, (short)0, ChatColor.RED + new LocalizedChatMessage(ChatConstant.UI_TNT_DEFUSER).getMessage(player.getLocale()));
-            player.getInventory().setItem(4, shears);
+            player.getInventory().setItem(5, shears);
         }
         event.setJoinMessage(null);
         for (Player player1 : Bukkit.getOnlinePlayers()) {

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/tutorial/DisplayHandler.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/tutorial/DisplayHandler.java
@@ -1,0 +1,116 @@
+package in.twizmwaz.cardinal.module.modules.tutorial;
+
+import in.twizmwaz.cardinal.chat.ChatConstant;
+import in.twizmwaz.cardinal.chat.LocalizedChatMessage;
+import in.twizmwaz.cardinal.util.ChatUtils;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class DisplayHandler {
+
+    private Player player;
+    private Tutorial tutorial;
+    private int pos = 0;
+
+    public DisplayHandler(Player player, Tutorial tutorial) {
+        this.player = player;
+        this.tutorial = tutorial;
+    }
+
+    public void displayNext() {
+        if (++this.pos >= this.tutorial.getAllStages().size()) {
+            this.pos = this.tutorial.getAllStages().size() - 1;
+            return;
+        }
+        this.displayCurrent();
+    }
+
+    public void displayPrev() {
+        if (--this.pos < 0) {
+            this.pos = 0;
+            return;
+        }
+        this.displayCurrent();
+    }
+
+    private void displayCurrent() {
+        Stage stage = this.tutorial.getAllStages().get(this.pos);
+
+
+        if (stage == this.tutorial.getPrefix() || stage == this.tutorial.getSuffix()) {
+            this.player.playSound(this.player.getLocation(), Sound.PISTON_EXTEND, 0.5f, 2);
+            if (stage == this.tutorial.getPrefix()) {
+                this.player.sendMessage("");
+            }
+        }
+
+
+        this.player.sendMessage("");
+        this.player.sendMessage(stage.getFormattedTitle());
+
+        for (String line: stage.getLines()) {
+            this.player.sendMessage(line);
+        }
+        this.player.sendMessage("");
+
+        if (stage.getTeleport() != null) {
+            Location location = stage.getTeleport().getRandomPoint().getLocation();
+            if (!location.getBlock().getType().equals(Material.AIR) || !location.add(0, 1, 0).getBlock().getType().equals(Material.AIR)) {
+                this.player.sendMessage("   " + ChatColor.YELLOW + new LocalizedChatMessage(ChatConstant.ERROR_TUTORIAL_TP).getMessage(ChatUtils.getLocale(this.player)));
+            } else {
+                this.player.setFlying(true);
+                this.player.teleport(stage.getTeleport().getRandomPoint().getLocation());
+                this.player.playSound(this.player.getLocation(), Sound.ENDERMAN_TELEPORT, 0.5f, 1);
+            }
+        }
+
+        this.updateItem(player);
+    }
+
+    private void updateItem(Player player) {
+        ItemStack emerald = player.getItemInHand();
+        ItemMeta meta = emerald.getItemMeta();
+
+        String left = null;
+        String right = null;
+
+        StringBuilder name = new StringBuilder();
+        String sep = "";
+
+        if (this.pos > 0) {
+            left = ChatColor.RED + this.tutorial.getAllStages().get(this.pos - 1).getTitle();
+        }
+
+        if (this.pos < this.tutorial.getAllStages().size() - 1) {
+            right = ChatColor.GREEN + this.tutorial.getAllStages().get(this.pos + 1).getTitle();
+        }
+
+        if (left != null && right != null) {
+            sep = ChatColor.AQUA + " | ";
+        }
+
+        if (left != null) {
+            name.append(ChatColor.GRAY).append("Left click ").append(ChatColor.AQUA).append("« ").append(left).append(sep);
+        }
+
+        if (right != null) {
+            name.append(right).append(" ").append(ChatColor.AQUA).append("» ").append(ChatColor.GRAY).append("Right click");
+        }
+
+        meta.setDisplayName(name.toString());
+        emerald.setItemMeta(meta);
+
+        for (int pos: player.getInventory().all(Material.EMERALD).keySet()) {
+            player.getInventory().setItem(pos, emerald);
+        }
+    }
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/tutorial/Stage.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/tutorial/Stage.java
@@ -1,0 +1,35 @@
+package in.twizmwaz.cardinal.module.modules.tutorial;
+
+import in.twizmwaz.cardinal.module.modules.regions.RegionModule;
+import org.bukkit.ChatColor;
+
+import java.util.List;
+
+public class Stage {
+
+    private String title;
+    private List<String> lines;
+    private RegionModule teleport;
+
+    public Stage(String title, List<String> lines, RegionModule teleport) {
+        this.title = title;
+        this.lines = lines;
+        this.teleport = teleport;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getFormattedTitle() {
+        return "   " + ChatColor.YELLOW + title;
+    }
+
+    public List<String> getLines() {
+        return lines;
+    }
+
+    public RegionModule getTeleport() {
+        return teleport;
+    }
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/tutorial/Tutorial.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/tutorial/Tutorial.java
@@ -1,0 +1,100 @@
+package in.twizmwaz.cardinal.module.modules.tutorial;
+
+import in.twizmwaz.cardinal.GameHandler;
+import in.twizmwaz.cardinal.chat.ChatConstant;
+import in.twizmwaz.cardinal.chat.LocalizedChatMessage;
+import in.twizmwaz.cardinal.event.PlayerChangeTeamEvent;
+import in.twizmwaz.cardinal.module.Module;
+import in.twizmwaz.cardinal.util.ChatUtils;
+import in.twizmwaz.cardinal.util.PlayerUtils;
+import in.twizmwaz.cardinal.util.TeamUtils;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Tutorial implements Module {
+
+    private Stage prefix;
+    private List<Stage> stages;
+    private Stage suffix;
+
+    private List<Stage> allStages = new ArrayList<>();
+
+    private Map<Player, DisplayHandler> displayHandlerMap = new HashMap<>();
+
+    public Stage getPrefix() {
+        return prefix;
+    }
+
+    public List<Stage> getStages() {
+        return this.stages;
+    }
+
+    public List<Stage> getAllStages() {
+        return this.allStages;
+    }
+
+    public Stage getSuffix() {
+        return suffix;
+    }
+
+    public Tutorial(Stage prefix, List<Stage> stages, Stage suffix) {
+        this.prefix = prefix;
+        this.stages = stages;
+        this.suffix = suffix;
+
+        this.allStages.add(prefix);
+        this.allStages.addAll(stages);
+        this.allStages.add(suffix);
+    }
+
+    @EventHandler
+    public void onPlayerRightClick(PlayerInteractEvent event) {
+        boolean condition = TeamUtils.getTeamByPlayer(event.getPlayer()).isObserver() && event.getPlayer().getItemInHand() != null && event.getPlayer().getItemInHand().getType().equals(Material.EMERALD);
+
+        if (!this.displayHandlerMap.containsKey(event.getPlayer())) {
+            this.displayHandlerMap.put(event.getPlayer(), new DisplayHandler(event.getPlayer(), this));
+        }
+
+        if (event.getAction() == Action.RIGHT_CLICK_AIR && condition) {
+            this.displayHandlerMap.get(event.getPlayer()).displayNext();
+        }
+        if (event.getAction() == Action.LEFT_CLICK_AIR && condition) {
+            this.displayHandlerMap.get(event.getPlayer()).displayPrev();
+        }
+    }
+
+    @EventHandler
+    public void onPlayerChangeTeam(PlayerChangeTeamEvent event) {
+        if (event.getNewTeam().isObserver()) {
+            this.displayHandlerMap.remove(event.getPlayer());
+        }
+    }
+
+    @Override
+    public void unload() {
+        HandlerList.unregisterAll(this);
+    }
+
+    public static ItemStack getEmerald(Player player) {
+        if (GameHandler.getGameHandler().getMatch().getModules().getModules(Tutorial.class).size() > 0) {
+            ItemStack emerald = new ItemStack(Material.EMERALD);
+            ItemMeta meta = emerald.getItemMeta();
+            meta.setDisplayName(ChatColor.GOLD + new LocalizedChatMessage(ChatConstant.UI_TUTORIAL_VIEW).getMessage(ChatUtils.getLocale(player)));
+            emerald.setItemMeta(meta);
+            return emerald;
+        }
+        return new ItemStack(Material.AIR);
+    }
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/tutorial/TutorialBuilder.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/tutorial/TutorialBuilder.java
@@ -1,0 +1,55 @@
+package in.twizmwaz.cardinal.module.modules.tutorial;
+
+import in.twizmwaz.cardinal.match.Match;
+import in.twizmwaz.cardinal.module.ModuleBuilder;
+import in.twizmwaz.cardinal.module.ModuleCollection;
+import in.twizmwaz.cardinal.module.modules.regions.RegionModule;
+import in.twizmwaz.cardinal.module.modules.regions.RegionModuleBuilder;
+import org.bukkit.ChatColor;
+import org.jdom2.Element;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TutorialBuilder implements ModuleBuilder {
+
+    @Override
+    public ModuleCollection load(Match match) {
+        ModuleCollection<Tutorial> result = new ModuleCollection<>();
+        Stage prefix = null;
+        Stage suffix = null;
+
+        List<Stage> stages = new ArrayList<>();
+        for (Element tutorial: match.getDocument().getRootElement().getChildren("tutorial")) {
+            for (Element stage: tutorial.getChildren("stage")) {
+                stages.add(parseStage(stage));
+            }
+
+            if (prefix == null) {
+                Element prefixElement = tutorial.getChild("prefix");
+                if (prefixElement != null) {
+                    prefix = parseStage(prefixElement.getChild("stage"));
+                    suffix = parseStage(tutorial.getChild("suffix").getChild("stage"));
+                }
+            }
+        }
+        if ((prefix != null && suffix != null) || !stages.isEmpty()) {
+            result.add(new Tutorial(prefix, stages, suffix));
+        }
+        return result;
+    }
+
+    private Stage parseStage(Element stage) {
+        String title = ChatColor.translateAlternateColorCodes('`', stage.getAttributeValue("title"));
+        List<String> lines = new ArrayList<>();
+        RegionModule region = null;
+        for (Element line: stage.getChild("message").getChildren("line")) {
+            lines.add(ChatColor.translateAlternateColorCodes('`', line.getValue()));
+        }
+        Element teleport = stage.getChild("teleport");
+        if (teleport != null) {
+            region = RegionModuleBuilder.getRegion(teleport.getChildren().get(0));
+        }
+        return new Stage(title, lines, region);
+    }
+}


### PR DESCRIPTION
This PR adds full support for [map tutorials](https://docs.oc.tc/modules/tutorial)

Features include:
* Emerald for switching between tutorial stages
 * The emerald is only added to the player's inventory on maps which have a tutorial
 * As on Overcast, the emerald's display name changes to indicate the player's progression through the tutorial
* Formatted tutorial stage titles
* Optional teleports at each tutorial stage
 * Teleports are cancelled, with a localized warning message displayed, if the area is obstructed