### PR TITLE
Add Bukkit flavor, and version check

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/Cardinal.java
+++ b/src/main/java/in/twizmwaz/cardinal/Cardinal.java
@@ -96,6 +96,18 @@ public class Cardinal extends JavaPlugin {
     @Override
     public void onEnable() {
         instance = this;
+        if (Bukkit.getName().equals("SportBukkit")) {
+            if (!getServer().getClass().getPackage().getName().contains("v1_8_R")) {
+                getLogger().log(Level.SEVERE, "Failed to load because you're running a invalid version of SportBukkit, disabling plugin...");
+                getLogger().log(Level.INFO, "Please see wiki for more information, https://github.com/twizmwazin/CardinalPGM/wiki/Installing-CardinalPGM.");
+                setEnabled(false);
+                return;
+            }
+        } else {
+            getLogger().log(Level.SEVERE, "Dependency SportBukkit not found, disabling plugin...");
+            setEnabled(false);
+            return;
+        }
         try {
             localeHandler = new LocaleHandler(this);
         } catch (IOException | JDOMException e) {


### PR DESCRIPTION
I wrote this little tidbit of code for another project, and added it into CardinalPGM. Your more than welcome to use it if you wish. It checks to make sure the user is using SportBukkit, and if they aren't it disables the plugin. If they are, it then goes on to check the version and if they aren't using SportBukkit 1.8 it will disable the plugin, and forward them to the wiki page to get more information about what CardinalPGM's current supported SportBukkit version might be. 