### PR TITLE
Add more localisations - 'Time elapsed'

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/chat/ChatConstant.java
+++ b/src/main/java/in/twizmwaz/cardinal/chat/ChatConstant.java
@@ -221,7 +221,8 @@ public enum  ChatConstant {
     UI_GLOBAL_MUTE_DISABLED("userInterface.globalMuteDisabled"),
     UI_DEFAULT_CHANNEL_GLOBAL("userInterface.defaultChannelGlobal"),
     UI_DEFAULT_CHANNEL_ADMIN("userInterface.defaultChannelAdmin"),
-    UI_DEFAULT_CHANNEL_TEAM("userInterface.defaultChannelTeam");
+    UI_DEFAULT_CHANNEL_TEAM("userInterface.defaultChannelTeam"),
+    UI_TIME_ELAPSED("userInteface.timeElapsed");
     
     private final String path;
 

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/timeNotifications/TimeNotifications.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/timeNotifications/TimeNotifications.java
@@ -9,6 +9,7 @@ import in.twizmwaz.cardinal.module.modules.matchTimer.MatchTimer;
 import in.twizmwaz.cardinal.module.modules.timeLimit.TimeLimit;
 import in.twizmwaz.cardinal.util.ChatUtils;
 import in.twizmwaz.cardinal.util.StringUtils;
+
 import org.bukkit.ChatColor;
 import org.bukkit.event.HandlerList;
 
@@ -32,7 +33,7 @@ public class TimeNotifications implements TaskedModule {
             double timeRemaining;
             if (TimeLimit.getMatchTimeLimit() == 0) {
                 if (time >= nextTimeMessage) {
-                    ChatUtils.getGlobalChannel().sendLocalizedMessage(new UnlocalizedChatMessage(ChatColor.AQUA + "Time Elapsed: " + ChatColor.GREEN + StringUtils.formatTime(nextTimeMessage)));
+                    ChatUtils.getGlobalChannel().sendLocalizedMessage(new UnlocalizedChatMessage(ChatColor.AQUA + "{0}", new LocalizedChatMessage(ChatConstant.UI_TIME_ELAPSED, new UnlocalizedChatMessage(ChatColor.GREEN + StringUtils.formatTime(nextTimeMessage)))));
                     nextTimeMessage += 300;
                 }
                 return;

--- a/src/main/resources/lang/en.xml
+++ b/src/main/resources/lang/en.xml
@@ -221,6 +221,7 @@
         <defaultChannelGlobal>Changed default channel to global chat.</defaultChannelGlobal>
         <defaultChannelAdmin>Changed default channel to administrator chat.</defaultChannelAdmin>
         <defaultChannelTeam>Changed default channel to team chat.</defaultChannelTeam>
+        <timeElapsed>Time elapsed: {0}</timeElapsed>
     </userInterface>
     <deathMsg>
         <explosionSelf>{0} 'sploded</explosionSelf>


### PR DESCRIPTION
I've made this pull request because "elapsed" is quite an advanced English word. I feel that it would be best for everyone if it could be localised :)