### PR TITLE
Add livestreamer rank

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/Cardinal.java
+++ b/src/main/java/in/twizmwaz/cardinal/Cardinal.java
@@ -92,6 +92,7 @@ public class Cardinal extends JavaPlugin {
         cmdRegister.register(ScoreCommand.class);
         cmdRegister.register(ProximityCommand.class);
         cmdRegister.register(BroadcastCommands.class);
+        cmdRegister.register(LivestreamerCommand.class);
     }
 
     @Override

--- a/src/main/java/in/twizmwaz/cardinal/chat/ChatConstant.java
+++ b/src/main/java/in/twizmwaz/cardinal/chat/ChatConstant.java
@@ -84,6 +84,8 @@ public enum  ChatConstant {
     ERROR_GLOBAL_MUTE_ENABLED("error.globalMuteEnabled"),
     ERROR_NOT_ENOUGH_ARGS_BROADCAST("error.notEnoughArgsBroadcast"),
     ERROR_NOT_ENOUGH_ARGS_SAY("error.notEnoughArgsSay"),
+    ERROR_LIVESTREAMER_NO_JOIN("error.livestreamerNoJoin"),
+    ERROR_LIVESTREAMER_NO_CLASS("error.livestreamerNoClass"),
     
     GENERIC_MAP_SET("generic.mapSet"),
     GENERIC_MARKED_FOR_RELOADING("generic.markedForReloading"),

--- a/src/main/java/in/twizmwaz/cardinal/command/ChatCommands.java
+++ b/src/main/java/in/twizmwaz/cardinal/command/ChatCommands.java
@@ -42,6 +42,11 @@ public class ChatCommands {
     public static void global(final CommandContext cmd, CommandSender sender) throws CommandException {
         String locale = ChatUtils.getLocale(sender);
         if (sender instanceof Player) {
+            Player player = (Player) sender;
+            if (PermissionModule.isLivestreamer(player.getUniqueId()) && !player.hasPermission("cardinal.livestreamer.bypass") && GameHandler.getGameHandler().getMatch().isRunning()) {
+                player.sendMessage(ChatColor.RED + "Livestreamers may not use this command whilst the match is running!");
+                return;
+            }
             if (cmd.argsLength() == 0) {
                 ((Player) sender).setMetadata("default-channel", new LazyMetadataValue(GameHandler.getGameHandler().getPlugin(), LazyMetadataValue.CacheStrategy.NEVER_CACHE, new Channel(ChatUtils.ChannelType.GLOBAL)));
                 sender.sendMessage(ChatColor.YELLOW + new LocalizedChatMessage(ChatConstant.UI_DEFAULT_CHANNEL_GLOBAL).getMessage(locale));

--- a/src/main/java/in/twizmwaz/cardinal/command/ClassCommands.java
+++ b/src/main/java/in/twizmwaz/cardinal/command/ClassCommands.java
@@ -3,12 +3,16 @@ package in.twizmwaz.cardinal.command;
 import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
 import com.sk89q.minecraft.util.commands.CommandException;
+
 import in.twizmwaz.cardinal.GameHandler;
 import in.twizmwaz.cardinal.chat.ChatConstant;
 import in.twizmwaz.cardinal.chat.LocalizedChatMessage;
+import in.twizmwaz.cardinal.chat.UnlocalizedChatMessage;
 import in.twizmwaz.cardinal.event.ClassChangeEvent;
 import in.twizmwaz.cardinal.module.modules.classModule.ClassModule;
+import in.twizmwaz.cardinal.module.modules.permissions.PermissionModule;
 import in.twizmwaz.cardinal.util.ChatUtils;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -30,6 +34,12 @@ public class ClassCommands {
     @Command(aliases = {"class"}, desc = "Allows you to change your class.")
     public static void classCommand(final CommandContext cmd, CommandSender sender) throws CommandException {
         if (sender instanceof Player) {
+            Player player = (Player) sender;
+            if (PermissionModule.isLivestreamer(player.getUniqueId()) && !player.hasPermission("cardinal.livestreamer.bypass")) {
+                player.sendMessage(new UnlocalizedChatMessage(ChatColor.RED + "{0}", new LocalizedChatMessage(ChatConstant.ERROR_LIVESTREAMER_NO_CLASS)).getMessage(player.getLocale()));
+                return;
+            }
+
             if (GameHandler.getGameHandler().getMatch().getModules().getModule(ClassModule.class) != null) {
                 if (cmd.argsLength() == 0) {
                     if (ClassModule.getClassByPlayer((Player) sender) != null) {

--- a/src/main/java/in/twizmwaz/cardinal/command/JoinCommand.java
+++ b/src/main/java/in/twizmwaz/cardinal/command/JoinCommand.java
@@ -3,13 +3,17 @@ package in.twizmwaz.cardinal.command;
 import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
 import com.sk89q.minecraft.util.commands.CommandException;
+
 import in.twizmwaz.cardinal.GameHandler;
 import in.twizmwaz.cardinal.chat.ChatConstant;
 import in.twizmwaz.cardinal.chat.LocalizedChatMessage;
+import in.twizmwaz.cardinal.chat.UnlocalizedChatMessage;
 import in.twizmwaz.cardinal.match.MatchState;
+import in.twizmwaz.cardinal.module.modules.permissions.PermissionModule;
 import in.twizmwaz.cardinal.module.modules.team.TeamModule;
 import in.twizmwaz.cardinal.util.ChatUtils;
 import in.twizmwaz.cardinal.util.TeamUtils;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -20,6 +24,8 @@ public class JoinCommand {
     @Command(aliases = {"join", "play"}, desc = "Join a team.", usage = "[team]")
     public static void join(final CommandContext cmd, CommandSender sender) throws CommandException {
         if (sender instanceof Player) {
+            Player player = (Player) sender;
+
             TeamModule team = null;
             if (GameHandler.getGameHandler().getMatch().getState().equals(MatchState.ENDED) || GameHandler.getGameHandler().getMatch().getState().equals(MatchState.CYCLING)) {
                 ChatUtils.sendWarningMessage((Player) sender, ChatColor.RED + new LocalizedChatMessage(ChatConstant.ERROR_MATCH_OVER).getMessage(((Player) sender).getLocale()));
@@ -36,6 +42,11 @@ public class JoinCommand {
                     }
                 }
                 if (team != null) {
+                    if (PermissionModule.isLivestreamer(player.getUniqueId()) && !player.hasPermission("cardinal.livestreamer.bypass") && !team.isObserver()) {
+                        player.sendMessage(new UnlocalizedChatMessage(ChatColor.RED + "{0}", new LocalizedChatMessage(ChatConstant.ERROR_LIVESTREAMER_NO_JOIN)).getMessage(player.getLocale()));
+                        return;
+                    }
+
                     if (!team.contains(sender)) {
                         team.add((Player) sender, false);
                     } else {

--- a/src/main/java/in/twizmwaz/cardinal/command/LivestreamerCommand.java
+++ b/src/main/java/in/twizmwaz/cardinal/command/LivestreamerCommand.java
@@ -1,0 +1,106 @@
+package in.twizmwaz.cardinal.command;
+
+import in.twizmwaz.cardinal.GameHandler;
+import in.twizmwaz.cardinal.chat.ChatConstant;
+import in.twizmwaz.cardinal.chat.LocalizedChatMessage;
+import in.twizmwaz.cardinal.event.PlayerNameUpdateEvent;
+import in.twizmwaz.cardinal.match.MatchState;
+import in.twizmwaz.cardinal.module.modules.classModule.ClassModule;
+import in.twizmwaz.cardinal.module.modules.observers.ObserverModule;
+import in.twizmwaz.cardinal.module.modules.permissions.PermissionModule;
+import in.twizmwaz.cardinal.util.ItemUtils;
+import in.twizmwaz.cardinal.util.TeamUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import com.sk89q.minecraft.util.commands.Command;
+import com.sk89q.minecraft.util.commands.CommandContext;
+import com.sk89q.minecraft.util.commands.CommandException;
+import com.sk89q.minecraft.util.commands.CommandPermissions;
+
+public class LivestreamerCommand {
+    @Command(aliases = {"live", "livestreamer"}, desc = "Give a player the rank of livestreamer", usage = "<player>", min = 1, max = 1)
+    @CommandPermissions("cardinal.admin.live")
+    public static void live(CommandContext cmd, CommandSender sender) throws CommandException {
+        OfflinePlayer livestreamer = Bukkit.getOfflinePlayer(cmd.getString(0));
+        if (livestreamer != null) {
+            if (!livestreamer.isOp()) {
+                if (!PermissionModule.isLivestreamer(livestreamer.getUniqueId()) && !PermissionModule.isMod(livestreamer.getUniqueId())) {
+                    List<String> players = GameHandler.getGameHandler().getPlugin().getConfig().getStringList("permissions.Livestreamer.players");
+                    players.add(livestreamer.getUniqueId().toString());
+                    GameHandler.getGameHandler().getPlugin().getConfig().set("permissions.Livestreamer.players", players);
+                    GameHandler.getGameHandler().getPlugin().saveConfig();
+                    sender.sendMessage(ChatColor.GREEN + "You gave livestreamer permissions to " + TeamUtils.getTeamColorByPlayer(livestreamer) + (livestreamer.isOnline() ? ((Player) livestreamer).getDisplayName() : livestreamer.getName()));
+                    if (livestreamer.isOnline()) {
+                        ((Player) livestreamer).sendMessage(ChatColor.GREEN + "You are now a livestreamer!");
+                        for (String permission : GameHandler.getGameHandler().getPlugin().getConfig().getStringList("permissions.Livestreamer.permissions")) {
+                            GameHandler.getGameHandler().getMatch().getModules().getModules(PermissionModule.class).get(0).enablePermission((Player) livestreamer, permission);
+                        }
+                        Bukkit.getServer().getPluginManager().callEvent(new PlayerNameUpdateEvent((Player) livestreamer));
+                        if (livestreamer.isOnline()) {
+                            if (!GameHandler.getGameHandler().getMatch().getState().equals(MatchState.ENDED)) {
+                                ItemStack picker = ItemUtils.createItem(Material.LEATHER_HELMET, 1, (short) 0,
+                                        ChatColor.GREEN + "" + ChatColor.BOLD + (GameHandler.getGameHandler().getMatch().getModules().getModule(ClassModule.class) != null ? new LocalizedChatMessage(ChatConstant.UI_TEAM_CLASS_SELECTION).getMessage(((Player) livestreamer).getLocale()) : new LocalizedChatMessage(ChatConstant.UI_TEAM_SELECTION).getMessage(((Player) livestreamer).getLocale())),
+                                        Arrays.asList(ChatColor.DARK_PURPLE + new LocalizedChatMessage(ChatConstant.UI_TEAM_JOIN_TIP).getMessage(((Player) livestreamer).getLocale())));
+                                ((Player) livestreamer).getInventory().setItem(2, picker);
+                            }
+                        }
+                    }
+                } else {
+                    throw new CommandException("The player specified is already a livestreamer!");
+                }
+            } else {
+                throw new CommandException("The player specified is already op!");
+            }
+        } else {
+            throw new CommandException("Unknown player specified!");
+        }
+    }
+
+    @Command(aliases = {"delive", "delivestreamer", "unlive", "unlivestreamer"}, desc = "Remove a player from the rank of livestreamer", usage = "<player>", min = 1, max = 1)
+    @CommandPermissions("cardinal.admin.delive")
+    public static void demod(CommandContext cmd, CommandSender sender) throws CommandException {
+        OfflinePlayer livestreamer = Bukkit.getOfflinePlayer(cmd.getString(0));
+        if (livestreamer != null) {
+            if (!livestreamer.isOp()) {
+                if (PermissionModule.isLivestreamer(livestreamer.getUniqueId())) {
+                    List<String> players = GameHandler.getGameHandler().getPlugin().getConfig().getStringList("permissions.Livestreamer.players");
+                    players.remove(livestreamer.getUniqueId().toString());
+                    GameHandler.getGameHandler().getPlugin().getConfig().set("permissions.Livestreamer.players", players);
+                    sender.sendMessage(ChatColor.RED + "You removed livestreamer permissions from " + TeamUtils.getTeamColorByPlayer(livestreamer) + (livestreamer.isOnline() ? ((Player) livestreamer).getDisplayName() : livestreamer.getName()));
+                    if (livestreamer.isOnline()) {
+                        ((Player) livestreamer).sendMessage(ChatColor.RED + "You are no longer a livestreamer!");
+                        for (String permission : GameHandler.getGameHandler().getPlugin().getConfig().getStringList("permissions.Livestreamer.permissions")) {
+                            GameHandler.getGameHandler().getMatch().getModules().getModules(PermissionModule.class).get(0).disablePermission((Player) livestreamer, permission);
+                        }
+                        Bukkit.getServer().getPluginManager().callEvent(new PlayerNameUpdateEvent((Player) livestreamer));
+                        if (livestreamer.isOnline()) {
+                            if (!GameHandler.getGameHandler().getMatch().getState().equals(MatchState.ENDED)) {
+                                ItemStack picker = ItemUtils.createItem(Material.LEATHER_HELMET, 1, (short) 0,
+                                        ChatColor.GREEN + "" + ChatColor.BOLD + (GameHandler.getGameHandler().getMatch().getModules().getModule(ClassModule.class) != null ? new LocalizedChatMessage(ChatConstant.UI_TEAM_CLASS_SELECTION).getMessage(((Player) livestreamer).getLocale()) : new LocalizedChatMessage(ChatConstant.UI_TEAM_SELECTION).getMessage(((Player) livestreamer).getLocale())),
+                                        Arrays.asList(ChatColor.DARK_PURPLE + new LocalizedChatMessage(ChatConstant.UI_TEAM_JOIN_TIP).getMessage(((Player) livestreamer).getLocale())));
+                                ((Player) livestreamer).getInventory().setItem(2, picker);
+                            }
+                        }
+                    }
+                } else {
+                    throw new CommandException("The player specified is not a livestreamer!");
+                }
+            } else {
+                throw new CommandException("The player specified is already op!");
+            }
+        } else {
+            throw new CommandException("Unknown player specified!");
+        }
+    }
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/permissions/PermissionModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/permissions/PermissionModule.java
@@ -59,10 +59,27 @@ public class PermissionModule implements Module {
             GameHandler.getGameHandler().getPlugin().getConfig().set("permissions.Moderator.players", players);
             GameHandler.getGameHandler().getPlugin().saveConfig();
         }
+        if (event.getPlayer().isOp() && GameHandler.getGameHandler().getPlugin().getConfig().getStringList("permissions.Livestreamer.players").contains(event.getPlayer().getUniqueId().toString())) {
+            List<String> players = new ArrayList<>();
+            players.addAll(GameHandler.getGameHandler().getPlugin().getConfig().getStringList("permissions.Livestreamer.players"));
+            players.remove(event.getPlayer().getUniqueId().toString());
+            GameHandler.getGameHandler().getPlugin().getConfig().set("permissions.Livestreamer.players", players);
+            GameHandler.getGameHandler().getPlugin().saveConfig();
+        }
+
         if (GameHandler.getGameHandler().getPlugin().getConfig().get("permissions.Moderator.players") != null) {
             for (String uuid : GameHandler.getGameHandler().getPlugin().getConfig().getStringList("permissions.Moderator.players")) {
                 if (event.getPlayer().getUniqueId().toString().equals(uuid)) {
                     for (String permission : GameHandler.getGameHandler().getPlugin().getConfig().getStringList("permissions.Moderator.permissions")) {
+                        attachmentMap.get(event.getPlayer()).setPermission(permission, true);
+                    }
+                }
+            }
+        }
+        if (GameHandler.getGameHandler().getPlugin().getConfig().get("permissions.Livestreamer.players") != null) {
+            for (String uuid : GameHandler.getGameHandler().getPlugin().getConfig().getStringList("permissions.Livestreamer.players")) {
+                if (event.getPlayer().getUniqueId().toString().equals(uuid)) {
+                    for (String permission : GameHandler.getGameHandler().getPlugin().getConfig().getStringList("permissions.Livestreamer.permissions")) {
                         attachmentMap.get(event.getPlayer()).setPermission(permission, true);
                     }
                 }
@@ -156,6 +173,10 @@ public class PermissionModule implements Module {
         return false;
     }
 
+    public static boolean isLivestreamer(UUID player) {
+        return GameHandler.getGameHandler().getPlugin().getConfig().getStringList("permissions.Livestreamer.players").contains(player.toString());
+    }
+
     public static boolean isStaff(OfflinePlayer player) {
         return isMod(player.getUniqueId()) || player.isOp();
     }
@@ -172,7 +193,10 @@ public class PermissionModule implements Module {
             stars += ChatColor.GOLD + star;
         } else if (isMod(event.getPlayer().getUniqueId())) {
             stars += ChatColor.RED + star;
+        } else if (isLivestreamer(event.getPlayer().getUniqueId())) {
+            stars += ChatColor.WHITE + "*";
         }
+
         if (devs.contains(event.getPlayer().getUniqueId())) {
             stars += ChatColor.DARK_PURPLE + star;
         }

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/teamPicker/TeamPicker.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/teamPicker/TeamPicker.java
@@ -3,12 +3,15 @@ package in.twizmwaz.cardinal.module.modules.teamPicker;
 import in.twizmwaz.cardinal.GameHandler;
 import in.twizmwaz.cardinal.chat.ChatConstant;
 import in.twizmwaz.cardinal.chat.LocalizedChatMessage;
+import in.twizmwaz.cardinal.chat.UnlocalizedChatMessage;
 import in.twizmwaz.cardinal.module.Module;
 import in.twizmwaz.cardinal.module.modules.classModule.ClassModule;
+import in.twizmwaz.cardinal.module.modules.permissions.PermissionModule;
 import in.twizmwaz.cardinal.module.modules.team.TeamModule;
 import in.twizmwaz.cardinal.util.ItemUtils;
 import in.twizmwaz.cardinal.util.MiscUtils;
 import in.twizmwaz.cardinal.util.TeamUtils;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -52,12 +55,20 @@ public class TeamPicker implements Module {
                 totalPlayers += team.size();
             }
         }
-        ItemStack autoJoin = ItemUtils.createItem(Material.CHAINMAIL_HELMET, 1, (short)0, ChatColor.GRAY + "" + ChatColor.BOLD + new LocalizedChatMessage(ChatConstant.UI_TEAM_JOIN_AUTO).getMessage(player.getLocale()), Arrays.asList((totalPlayers >= maxPlayers ? ChatColor.RED + "" : ChatColor.GREEN + "") + totalPlayers + ChatColor.GOLD + " / " + ChatColor.RED + "" + maxPlayers, ChatColor.AQUA + new LocalizedChatMessage(ChatConstant.UI_TEAM_JOIN_AUTO_LORE).getMessage(player.getLocale())));
+        String autoMessage = ChatColor.AQUA + new LocalizedChatMessage(ChatConstant.UI_TEAM_JOIN_AUTO_LORE).getMessage(player.getLocale());
+        if (PermissionModule.isLivestreamer(player.getUniqueId()) && !player.hasPermission("cardinal.livestreamer.bypass")) {
+            autoMessage = ChatColor.RED + new LocalizedChatMessage(ChatConstant.ERROR_LIVESTREAMER_NO_JOIN).getMessage(player.getLocale()); 
+        }
+        ItemStack autoJoin = ItemUtils.createItem(Material.CHAINMAIL_HELMET, 1, (short) 0, ChatColor.GRAY + "" + ChatColor.BOLD + new LocalizedChatMessage(ChatConstant.UI_TEAM_JOIN_AUTO).getMessage(player.getLocale()), Arrays.asList((totalPlayers >= maxPlayers ? ChatColor.RED + "" : ChatColor.GREEN + "") + totalPlayers + ChatColor.GOLD + " / " + ChatColor.RED + "" + maxPlayers, autoMessage));
         picker.setItem(item, autoJoin);
         item++;
         for (TeamModule team : GameHandler.getGameHandler().getMatch().getModules().getModules(TeamModule.class)) {
             if (!team.isObserver()) {
-                ItemStack teamStack = ItemUtils.createLeatherArmor(Material.LEATHER_HELMET, 1, team.getColor() + "" + ChatColor.BOLD + team.getName(), Arrays.asList((team.size() >= team.getMax() ? ChatColor.RED + "" : ChatColor.GREEN + "") + team.size() + ChatColor.GOLD + " / " + ChatColor.RED + "" + team.getMax(), ChatColor.GREEN + new LocalizedChatMessage(ChatConstant.UI_TEAM_CAN_PICK).getMessage(player.getLocale())), MiscUtils.convertChatColorToColor(team.getColor()));
+                String message = ChatColor.GREEN + new LocalizedChatMessage(ChatConstant.UI_TEAM_CAN_PICK).getMessage(player.getLocale());
+                if (PermissionModule.isLivestreamer(player.getUniqueId()) && !player.hasPermission("cardinal.livestreamer.bypass")) {
+                    message = ChatColor.RED + new LocalizedChatMessage(ChatConstant.ERROR_LIVESTREAMER_NO_JOIN).getMessage(player.getLocale()); 
+                }
+                ItemStack teamStack = ItemUtils.createLeatherArmor(Material.LEATHER_HELMET, 1, team.getColor() + "" + ChatColor.BOLD + team.getName(), Arrays.asList((team.size() >= team.getMax() ? ChatColor.RED + "" : ChatColor.GREEN + "") + team.size() + ChatColor.GOLD + " / " + ChatColor.RED + "" + team.getMax(), message), MiscUtils.convertChatColorToColor(team.getColor()));
                 picker.setItem(item, teamStack);
                 item++;
             }
@@ -66,6 +77,10 @@ public class TeamPicker implements Module {
         for (ClassModule classModule : GameHandler.getGameHandler().getMatch().getModules().getModules(ClassModule.class)) {
             ItemStack classStack = ItemUtils.createItem(classModule.getIcon(), 1, (short)0, ChatColor.GREEN + classModule.getName(), Arrays.asList(ChatColor.GOLD + classModule.getLongDescription()));
             ItemMeta classMeta = classStack.getItemMeta();
+            if (PermissionModule.isLivestreamer(player.getUniqueId()) && !player.hasPermission("cardinal.livestreamer.bypass")) {
+                classMeta.setLore(Arrays.asList(new UnlocalizedChatMessage(ChatColor.RED + "{0}", new LocalizedChatMessage(ChatConstant.ERROR_LIVESTREAMER_NO_CLASS)).getMessage(player.getLocale()))); 
+            }
+
             if (classModule.equals(ClassModule.getClassByPlayer(player))) {
                 classStack.addUnsafeEnchantment(Enchantment.ARROW_INFINITE, 1);
             }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -16,6 +16,11 @@ permissions:
     permissions:
     - cardinal.chat.global
     - cardinal.chat.team
+  Livestreamer:
+    permissions:
+    - cardinal.chat.team
+    - cardinal.punish.warn
+    players:
   Moderator:
     permissions:
     - cardinal.say

--- a/src/main/resources/lang/en.xml
+++ b/src/main/resources/lang/en.xml
@@ -78,6 +78,8 @@
         <playableLeave>You may not leave the playing field</playableLeave>
         <playableInteract>You may not interact with blocks outside of the playing field</playableInteract>
         <globalMuteEnabled>You cannot talk in chat while global mute is enabled.</globalMuteEnabled>
+        <livestreamerNoJoin>Livestreamers may not join a team!</livestreamerNoJoin>
+        <livestreamerNoClass>Livestreamers may not pick a class!</livestreamerNoClass>
     </error>
     <generic>
         <mapSet>Next map set to {0}</mapSet>


### PR DESCRIPTION
@TiTi-418 suggested this so I implemented it.

Livestreamers may not chat in the global chat until the game has ended, nor join a team. However, if you give them the permission ```cardinal.livestreamer.bypass```, they can join a team and speak in global chat.