### PR TITLE
Add more aliases for /map and /next

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/command/MapCommands.java
+++ b/src/main/java/in/twizmwaz/cardinal/command/MapCommands.java
@@ -14,7 +14,7 @@ import org.bukkit.command.CommandSender;
 
 public class MapCommands {
 
-    @Command(aliases = {"map"}, desc = "Shows information about the currently playing map.", usage = "")
+    @Command(aliases = {"map", "mapinfo"}, desc = "Shows information about the currently playing map.", usage = "")
     public static void map(final CommandContext args, CommandSender sender) throws CommandException {
         LoadedMap mapInfo;
         if (args.argsLength() == 0) mapInfo = GameHandler.getGameHandler().getMatch().getLoadedMap();
@@ -59,7 +59,7 @@ public class MapCommands {
         sender.sendMessage(ChatColor.DARK_PURPLE + "" + ChatColor.BOLD + new LocalizedChatMessage(ChatConstant.UI_MAP_MAX).getMessage(ChatUtils.getLocale(sender)) + ": " + ChatColor.RESET + "" + ChatColor.GOLD + mapInfo.getMaxPlayers());
     }
 
-    @Command(aliases = {"next", "nextmap", "nm", "mn"}, desc = "Shows next map.", usage = "")
+    @Command(aliases = {"next", "nextmap", "nm", "mn", "mapnext"}, desc = "Shows next map.", usage = "")
     public static void next(final CommandContext cmd, CommandSender sender) {
         LoadedMap next = GameHandler.getGameHandler().getRotation().getNext();
         if (next.getAuthors().size() == 1) {


### PR DESCRIPTION
Sorry! I just noticed that these aliases were in PGM, I hope you don't think it is commit farming!

Aliases added:
* /mapinfo (for /map)
* /mapnext (for /next)