### PR TITLE
Update the player's inventory when it is reset

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/observers/ObserverModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/observers/ObserverModule.java
@@ -16,6 +16,7 @@ import in.twizmwaz.cardinal.module.modules.team.TeamModule;
 import in.twizmwaz.cardinal.module.modules.tutorial.Tutorial;
 import in.twizmwaz.cardinal.util.ItemUtils;
 import in.twizmwaz.cardinal.util.TeamUtils;
+
 import org.bukkit.*;
 import org.bukkit.block.*;
 import org.bukkit.entity.ItemFrame;
@@ -74,6 +75,8 @@ public class ObserverModule implements Module {
             ItemStack shears = ItemUtils.createItem(Material.SHEARS, 1, (short)0, ChatColor.RED + new LocalizedChatMessage(ChatConstant.UI_TNT_DEFUSER).getMessage(player.getLocale()));
             player.getInventory().setItem(5, shears);
         }
+        
+        player.updateInventory();
     }
 
     @EventHandler


### PR DESCRIPTION
The player's inventory should automatically be updated, however, it is a bug in Bukkit. ```player.updateInventory();``` is a temporary fix, hence it is deprecated. However, it seems that it hasn't been fixed.