### PR TITLE
[WIP] Add sounds and change how proximity calculates a touch distance

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/Cardinal.java
+++ b/src/main/java/in/twizmwaz/cardinal/Cardinal.java
@@ -92,6 +92,7 @@ public class Cardinal extends JavaPlugin {
         cmdRegister.register(ScoreCommand.class);
         cmdRegister.register(ProximityCommand.class);
         cmdRegister.register(BroadcastCommands.class);
+        cmdRegister.register(RequestCommand.class);
     }
 
     @Override

--- a/src/main/java/in/twizmwaz/cardinal/command/PunishmentCommands.java
+++ b/src/main/java/in/twizmwaz/cardinal/command/PunishmentCommands.java
@@ -10,12 +10,10 @@ import in.twizmwaz.cardinal.chat.LocalizedChatMessage;
 import in.twizmwaz.cardinal.module.modules.chatChannels.AdminChannel;
 import in.twizmwaz.cardinal.module.modules.chatChannels.ChatChannelModule;
 import in.twizmwaz.cardinal.module.modules.permissions.PermissionModule;
+import in.twizmwaz.cardinal.settings.Settings;
 import in.twizmwaz.cardinal.util.ChatUtils;
 import in.twizmwaz.cardinal.util.TeamUtils;
-import org.bukkit.BanList;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.OfflinePlayer;
+import org.bukkit.*;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -52,6 +50,9 @@ public class PunishmentCommands {
             warned.sendMessage(ChatColor.YELLOW + reason);
             warned.sendMessage(ChatColor.RED + reason);
             warned.sendMessage(ChatColor.RED + "" + ChatColor.MAGIC + "-------" + ChatColor.YELLOW + "WARNING" + ChatColor.RED + ChatColor.MAGIC + "-------");
+            if (Settings.getSettingByName("Sounds") != null && Settings.getSettingByName("Sounds").getValueByPlayer(warned).getValue().equalsIgnoreCase("on")) {
+                warned.playSound(warned.getLocation(), Sound.ENDERDRAGON_GROWL, (float) 1.0, (float) 2.0);
+            }
         } else {
             throw new CommandException(new LocalizedChatMessage(ChatConstant.ERROR_NO_PLAYER_MATCH).getMessage(ChatUtils.getLocale(sender)));
         }
@@ -109,7 +110,7 @@ public class PunishmentCommands {
         } else throw new CommandException(new LocalizedChatMessage(ChatConstant.ERROR_PLAYER_NOT_FOUND).getMessage(ChatUtils.getLocale(sender)));
     }
 
-    @Command(aliases = {"gmute"}, desc = "Enable/disable global mute.")
+    @Command(aliases = {"gmute", "muteall", "globalmute"}, desc = "Enable/disable global mute.")
     @CommandPermissions("cardinal.punish.mute")
     public static void gmute(CommandContext cmd, CommandSender sender) {
         boolean state = GameHandler.getGameHandler().toggleGlobalMute();

--- a/src/main/java/in/twizmwaz/cardinal/command/RequestCommand.java
+++ b/src/main/java/in/twizmwaz/cardinal/command/RequestCommand.java
@@ -1,0 +1,29 @@
+package in.twizmwaz.cardinal.command;
+
+import com.sk89q.minecraft.util.commands.Command;
+import com.sk89q.minecraft.util.commands.CommandContext;
+import com.sk89q.minecraft.util.commands.CommandException;
+import in.twizmwaz.cardinal.settings.Settings;
+import in.twizmwaz.cardinal.util.ChatUtils;
+import in.twizmwaz.cardinal.util.TeamUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Sound;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class RequestCommand {
+
+    @Command(aliases = {"request"}, desc = "Request an action to ranked players.", min = 1, usage = "<message>")
+    public static void request(final CommandContext cmd, CommandSender sender) throws CommandException {
+        sender.sendMessage(ChatColor.YELLOW + "Your request has been submitted");
+        ChatUtils.getAdminChannel().sendMessage("[" + ChatColor.GOLD + "A" + ChatColor.WHITE + "] " + TeamUtils.getTeamColorByPlayer((Player) sender) + ((Player) sender).getDisplayName() + ChatColor.RESET + ": " + cmd.getJoinedStrings(0));
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (Settings.getSettingByName("Sounds") != null && Settings.getSettingByName("Sounds").getValueByPlayer(player).getValue().equalsIgnoreCase("on")) {
+                if (player.hasPermission("cardinal.chat.admin")) {
+                    player.playSound(player.getLocation(), Sound.ORB_PICKUP, 10, 1);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/in/twizmwaz/cardinal/command/TeamCommands.java
+++ b/src/main/java/in/twizmwaz/cardinal/command/TeamCommands.java
@@ -57,7 +57,7 @@ public class TeamCommands {
         if (team != null) {
             String msg = cmd.getJoinedStrings(1);
             String locale = ChatUtils.getLocale(sender);
-            sender.sendMessage(ChatColor.GRAY + new LocalizedChatMessage(ChatConstant.GENERIC_TEAM_ALIAS, team.getCompleteName() + ChatColor.GRAY, team.getColor() + msg + ChatColor.GRAY).getMessage(locale));
+            ChatUtils.getGlobalChannel().sendMessage(ChatColor.GRAY + new LocalizedChatMessage(ChatConstant.GENERIC_TEAM_ALIAS, team.getCompleteName() + ChatColor.GRAY, team.getColor() + msg + ChatColor.GRAY).getMessage(locale));
             team.setName(msg);
             Bukkit.getServer().getPluginManager().callEvent(new TeamNameChangeEvent(team));
         } else {

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/match/MatchModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/match/MatchModule.java
@@ -1,5 +1,6 @@
 package in.twizmwaz.cardinal.module.modules.match;
 
+import in.twizmwaz.cardinal.Cardinal;
 import in.twizmwaz.cardinal.chat.ChatConstant;
 import in.twizmwaz.cardinal.chat.LocalizedChatMessage;
 import in.twizmwaz.cardinal.chat.UnlocalizedChatMessage;
@@ -7,11 +8,18 @@ import in.twizmwaz.cardinal.event.CycleCompleteEvent;
 import in.twizmwaz.cardinal.event.MatchEndEvent;
 import in.twizmwaz.cardinal.event.MatchStartEvent;
 import in.twizmwaz.cardinal.match.Match;
+import in.twizmwaz.cardinal.match.MatchState;
 import in.twizmwaz.cardinal.module.Module;
+import in.twizmwaz.cardinal.module.modules.snowflakes.Snowflakes;
+import in.twizmwaz.cardinal.module.modules.stats.MatchTracker;
+import in.twizmwaz.cardinal.module.modules.team.TeamModule;
+import in.twizmwaz.cardinal.module.modules.timeLimit.TimeLimit;
 import in.twizmwaz.cardinal.util.ChatUtils;
 import in.twizmwaz.cardinal.util.TeamUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -31,24 +39,28 @@ public class MatchModule implements Module {
     }
 
     @EventHandler
-    public void onMatchStart(MatchStartEvent event) {
-        ChatUtils.getGlobalChannel().sendLocalizedMessage(new UnlocalizedChatMessage(ChatColor.DARK_PURPLE + "# # # # # # # # # # # # # # # #"));
-        ChatUtils.getGlobalChannel().sendLocalizedMessage(new UnlocalizedChatMessage(ChatColor.DARK_PURPLE + "# # " + ChatColor.GOLD + "{0}" + ChatColor.DARK_PURPLE + " # #", new LocalizedChatMessage(ChatConstant.UI_MATCH_STARTED)));
-        ChatUtils.getGlobalChannel().sendLocalizedMessage(new UnlocalizedChatMessage(ChatColor.DARK_PURPLE + "# # # # # # # # # # # # # # # #"));
-    }
-
-    @EventHandler
     public void onMatchEnd(MatchEndEvent event) {
-        ChatUtils.getGlobalChannel().sendMessage(ChatColor.DARK_PURPLE + "# # # # # # # # # # # #");
-        ChatUtils.getGlobalChannel().sendLocalizedMessage(new UnlocalizedChatMessage(ChatColor.DARK_PURPLE + "# #    " + ChatColor.GOLD + "{0}" + ChatColor.DARK_PURPLE + "    # #", new LocalizedChatMessage(ChatConstant.UI_MATCH_OVER)));
         if (event.getTeam() != null) {
             if (event.getTeam().size() == 1) {
-                ChatUtils.getGlobalChannel().sendLocalizedMessage(new UnlocalizedChatMessage(ChatColor.DARK_PURPLE + "# # {0}" + ChatColor.DARK_PURPLE + " # #", new LocalizedChatMessage(ChatConstant.UI_MATCH_WIN, event.getTeam().getColor() + ((Player) event.getTeam().get(0)).getName())));
+                ChatUtils.getGlobalChannel().sendLocalizedMessage(new LocalizedChatMessage(ChatConstant.UI_MATCH_WIN, event.getTeam().getColor() + ((Player) event.getTeam().get(0)).getName() + ChatColor.WHITE + ""));
+                //sendTitle.((Player) event.getTeam().get(0)).getName() + ChatColor.WHITE + " wins!");
             } else {
-                ChatUtils.getGlobalChannel().sendLocalizedMessage(new UnlocalizedChatMessage(ChatColor.DARK_PURPLE + "# # {0}" + ChatColor.DARK_PURPLE + " # #", new LocalizedChatMessage(ChatConstant.UI_MATCH_WIN, event.getTeam().getCompleteName())));
+                ChatUtils.getGlobalChannel().sendLocalizedMessage(new LocalizedChatMessage(ChatConstant.UI_MATCH_WIN, event.getTeam().getCompleteName() + ChatColor.WHITE + ""));
+                //sendTitle.(event.getTeam().getCompleteName() + ChatColor.WHITE + " wins!");
             }
         }
-        ChatUtils.getGlobalChannel().sendMessage(ChatColor.DARK_PURPLE + "# # # # # # # # # # # #");
+        TeamModule winner = TimeLimit.getMatchWinner();
+        /*if (event.getTeam() == winner) {
+            sendMessage.(ChatColor.GREEN + "Your team won!");
+            sendTitle. (ChatColor.GREEN + "Your team won!");
+        } else {
+            sendMessage.(ChatColor.RED + "Your team lost");
+            sendTitle. (ChatColor.RED + "Your team lost");
+        }*/
+        if (Cardinal.getInstance().getConfig().getBoolean("auto-whitelist")) {
+            Bukkit.getServer().setWhitelist(false);
+            ChatUtils.getGlobalChannel().sendMessage(ChatColor.GREEN + "The whitelist is now " + ChatColor.RED + "disabled.");
+        }
     }
 
     @EventHandler(priority = EventPriority.LOWEST)

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/monumentModes/MonumentModes.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/monumentModes/MonumentModes.java
@@ -6,10 +6,14 @@ import in.twizmwaz.cardinal.module.TaskedModule;
 import in.twizmwaz.cardinal.module.modules.cores.CoreObjective;
 import in.twizmwaz.cardinal.module.modules.destroyable.DestroyableObjective;
 import in.twizmwaz.cardinal.module.modules.matchTimer.MatchTimer;
+import in.twizmwaz.cardinal.settings.Settings;
 import in.twizmwaz.cardinal.util.ChatUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import org.bukkit.Sound;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 
 public class MonumentModes implements TaskedModule {
@@ -68,6 +72,11 @@ public class MonumentModes implements TaskedModule {
                 }
                 ChatUtils.getGlobalChannel().sendLocalizedMessage(new UnlocalizedChatMessage(ChatColor.DARK_AQUA + "> > > > " + ChatColor.RED + name + ChatColor.DARK_AQUA + " < < < <"));
                 this.ran = true;
+                for (Player player : Bukkit.getOnlinePlayers()) {
+                    if (Settings.getSettingByName("Sounds") != null && Settings.getSettingByName("Sounds").getValueByPlayer(player).getValue().equalsIgnoreCase("on")) {
+                        player.playSound(player.getLocation(), Sound.ZOMBIE_REMEDY, (float) 0.15, (float) 1.2);
+                    }
+                }
             }
         }
     }

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/startTimer/StartTimer.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/startTimer/StartTimer.java
@@ -1,5 +1,6 @@
 package in.twizmwaz.cardinal.module.modules.startTimer;
 
+import in.twizmwaz.cardinal.Cardinal;
 import in.twizmwaz.cardinal.GameHandler;
 import in.twizmwaz.cardinal.chat.ChatConstant;
 import in.twizmwaz.cardinal.chat.LocalizedChatMessage;
@@ -15,6 +16,7 @@ import in.twizmwaz.cardinal.util.ChatUtils;
 import in.twizmwaz.cardinal.util.TeamUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -55,10 +57,23 @@ public class StartTimer implements TaskedModule, Cancellable {
                             return;
                         }
                     }
-                    match.setState(MatchState.PLAYING);
-                    ChatUtils.getGlobalChannel().sendLocalizedMessage(new UnlocalizedChatMessage(ChatColor.GREEN + "{0}", new LocalizedChatMessage(ChatConstant.UI_MATCH_STARTED)));
-                    Bukkit.getServer().getPluginManager().callEvent(new MatchStartEvent());
                 }
+                if (Cardinal.getInstance().getConfig().getBoolean("auto-whitelist")) {
+                    int count2 = 0;
+                    for (OfflinePlayer player : Bukkit.getWhitelistedPlayers()) {
+                        player.setWhitelisted(false);
+                        count2++;
+                    }
+                    for (Player player : Bukkit.getOnlinePlayers()) {
+                        player.setWhitelisted(true);
+                    }
+                    Bukkit.getServer().setWhitelist(true);
+                    ChatUtils.getGlobalChannel().sendMessage(ChatColor.GREEN + "A number of " + ChatColor.GOLD + Bukkit.getOnlinePlayers().size() + ChatColor.GREEN + " player(s) has been added to the whitelist.");
+                    ChatUtils.getGlobalChannel().sendMessage(ChatColor.GREEN + "The whitelist is now " + ChatColor.GOLD + "enabled.");
+                }
+                match.setState(MatchState.PLAYING);
+                Bukkit.getServer().getPluginManager().callEvent(new MatchStartEvent());
+                ChatUtils.getGlobalChannel().sendLocalizedMessage(new UnlocalizedChatMessage(ChatColor.GREEN + "{0}", new LocalizedChatMessage(ChatConstant.UI_MATCH_STARTED)));
             }
             if (time <= 60 && time >= 20 && time % 20 == 0) {
                 for (Player player : Bukkit.getOnlinePlayers()) {
@@ -71,6 +86,22 @@ public class StartTimer implements TaskedModule, Cancellable {
                 for (Player player : Bukkit.getOnlinePlayers()) {
                     if (Settings.getSettingByName("Sounds") != null && Settings.getSettingByName("Sounds").getValueByPlayer(player).getValue().equalsIgnoreCase("on")) {
                         player.playSound(player.getLocation(), Sound.NOTE_PLING, 1, 2);
+                    }
+                }
+            }
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                if (!TeamUtils.getTeamByPlayer(player).isObserver()) {
+                    if (time == 3) {
+                        //sendTitle.(ChatColor.YELLOW + "3")
+                    }
+                    if (time == 2) {
+                        //sendTitle.(ChatColor.YELLOW + "2")
+                    }
+                    if (time == 1) {
+                        //sendTitle.(ChatColor.YELLOW + "1)
+                    }
+                    if (time == 0) {
+                        //sendTitle.(ChatColor.GREEN + "Go!")
                     }
                 }
             }

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/wools/WoolObjective.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/wools/WoolObjective.java
@@ -145,11 +145,7 @@ public class WoolObjective implements GameObjective {
                         this.touched = true;
                         if (touchMessage) {
                             double newProx;
-                            if (location != null) {
-                                newProx = location.distance(place.getVector());
-                            } else {
-                                newProx = player.getLocation().toVector().distance(place.getVector());
-                            }
+                            newProx = player.getLocation().toVector().distance(place.getVector());
                             if (!oldState || newProx < proximity) {
                                 proximity = newProx;
                             }
@@ -187,11 +183,7 @@ public class WoolObjective implements GameObjective {
                         this.touched = true;
                         if (touchMessage) {
                             double newProx;
-                            if (location != null) {
-                                newProx = location.distance(place.getVector());
-                            } else {
-                                newProx = player.getLocation().toVector().distance(place.getVector());
-                            }
+                            newProx = player.getLocation().toVector().distance(place.getVector());
                             if (!oldState || newProx < proximity) {
                                 proximity = newProx;
                             }


### PR DESCRIPTION
+ In ad507af I added toggleables sounds for warns & monument modes.
+ Now, in the 2bdea51 commit, the ```location``` is only needed to calculate the distance when a player  kill an enemy. In the case of a touch, proximity should get the distance between the player-monument, not the location-monument.
+ I was planing to add a request command, here's a gist to see how it is: https://gist.github.com/Alfalik/be1dfa2ba355f4464bcf

In addition, I'm just seeing if the code is correctly write and if it is, convert all the code in one commit.