### PR TITLE
Fix typos that caused infinite recursion

### DIFF
--- a/src/main/resources/lang/es.xml
+++ b/src/main/resources/lang/es.xml
@@ -221,7 +221,7 @@
         <timeElapsed>Tiempo transcurrido: {0}</timeElapsed>
         <matchReportUpload>Subiendo el reporte de la partida...</matchReportUpload>
         <matchReportSuccess>Reporte de la partida subido correctamente! Lo puedes ver en {0}</matchReportSuccess>
-        <matchReportFaied>Un error ha ocurrido al subir el reporte de la partida</matchReportFaied>
+        <matchReportFailed>Un error ha ocurrido al subir el reporte de la partida</matchReportFailed>
         <globalMuteEnabled>Silenciado global activado</globalMuteEnabled>
         <globalMuteDisabled>Silenciado global desactivado</globalMuteDisabled>
     </userInterface>

--- a/src/main/resources/lang/ko.xml
+++ b/src/main/resources/lang/ko.xml
@@ -212,7 +212,7 @@
         <version>이 서버는 {0}버전의 Cardinal을 실행중입니다.</version>
         <matchReportUpload>경기 정보를 업로드하는 중입니다...</matchReportUpload>
         <matchReportSuccess>경기 정보가 업로드 되었습니다 {0}에서 보실 수 있습니다</matchReportSuccess>
-        <matchReportFaied>경기 정보를 업로드하는 도중 오류가 발생했습니다</matchReportFaied>
+        <matchReportFailed>경기 정보를 업로드하는 도중 오류가 발생했습니다</matchReportFailed>
         <globalMuteEnabled>전체 뮤트가 활성화 되었습니다</globalMuteEnabled>
         <globalMuteDisabled>전체 뮤트가 비활성화 되었습니다</globalMuteDisabled>
         <defaultChannelGlobal>기본 채팅이 전체 채팅으로 변경되었습니다</defaultChannelGlobal>


### PR DESCRIPTION
It was only fixed in EN.xml, but ES and KO still had the typo.