### PR TITLE
Only move the rotation if the next map is the next map in the rotation

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/GameHandler.java
+++ b/src/main/java/in/twizmwaz/cardinal/GameHandler.java
@@ -44,7 +44,9 @@ public class GameHandler {
     }
 
     public void cycleAndMakeMatch() {
-        rotation.move();
+        if (rotation.getNext().equals(cycle.getMap())) {
+            rotation.move();            
+        }
         World oldMatchWorld = matchWorld == null ? null : matchWorld.get();
         cycle.run();
         if (match != null) match.unregisterModules();


### PR DESCRIPTION
Used on Overcast. It may not be the most useful thing for scrimmages, but I like having it on my server.

This PR will only move the position in the rotation if the next map is the next map in the rotation.