### PR TITLE
Add shortest commands for team commands

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/Cardinal.java
+++ b/src/main/java/in/twizmwaz/cardinal/Cardinal.java
@@ -139,6 +139,7 @@ public class Cardinal extends JavaPlugin {
         cmdRegister.register(SnowflakesCommand.class);
         cmdRegister.register(StartAndEndCommand.class);
         cmdRegister.register(TeamCommands.TeamParentCommand.class);
+        cmdRegister.register(TeamCommands.class);
         cmdRegister.register(TeleportCommands.class);
         cmdRegister.register(TimeLimitCommand.class);
         cmdRegister.register(WhitelistCommands.WhitelistParentCommand.class);


### PR DESCRIPTION
I've added shortest "aliases" for team commands. Also, now the shuffle command can only be executed if the match is waiting or starting and the team change name is sent to the global channel.

Here's a test https://youtu.be/c0Q9Q1gs068