### PR TITLE
Update scoreboard proximity color, fixes #797 & #802

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/scoreboard/GameObjectiveScoreboardHandler.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/scoreboard/GameObjectiveScoreboardHandler.java
@@ -36,9 +36,9 @@ public class GameObjectiveScoreboardHandler {
             if (wool.isComplete()) {
                 prefix = MiscUtil.convertDyeColorToChatColor(wool.getColor()) + " \u2B1B ";
             } else if (wool.isTouched() && (this.team == team || team.isObserver())) {
-                prefix = MiscUtil.convertDyeColorToChatColor(wool.getColor()) + " \u2592 " + (wool.showProximity() ? ChatColor.RESET + Numbers.convertToSubscript(wool.getProximity() == Double.POSITIVE_INFINITY || wool.getProximity() == Double.NEGATIVE_INFINITY ? wool.getProximity() : Math.round(wool.getProximity() * 10.0) / 10.0) + " " : "");
+                prefix = MiscUtil.convertDyeColorToChatColor(wool.getColor()) + " \u2592 " + (wool.showProximity() ? ChatColor.YELLOW + Numbers.convertToSubscript(wool.getProximity() == Double.POSITIVE_INFINITY || wool.getProximity() == Double.NEGATIVE_INFINITY ? wool.getProximity() : Math.round(wool.getProximity() * 10.0) / 10.0) + " " : "");
             } else if (this.team == team || team.isObserver()) {
-                prefix = MiscUtil.convertDyeColorToChatColor(wool.getColor()) + " \u2B1C " + (wool.showProximity() ? ChatColor.RESET + Numbers.convertToSubscript(wool.getProximity() == Double.POSITIVE_INFINITY || wool.getProximity() == Double.NEGATIVE_INFINITY ? wool.getProximity() : Math.round(wool.getProximity() * 10.0) / 10.0) + " " : "");
+                prefix = MiscUtil.convertDyeColorToChatColor(wool.getColor()) + " \u2B1C " + (wool.showProximity() ? ChatColor.GRAY + Numbers.convertToSubscript(wool.getProximity() == Double.POSITIVE_INFINITY || wool.getProximity() == Double.NEGATIVE_INFINITY ? wool.getProximity() : Math.round(wool.getProximity() * 10.0) / 10.0) + " " : "");
             } else {
                 prefix = MiscUtil.convertDyeColorToChatColor(wool.getColor()) + " \u2B1C ";
             }
@@ -49,7 +49,7 @@ public class GameObjectiveScoreboardHandler {
             } else if (core.isTouched() && this.team != team) {
                 prefix = ChatColor.YELLOW + " \u2733 ";
             } else if (this.team != team) {
-                prefix = ChatColor.RED + " \u2715 " + ChatColor.RESET + (core.showProximity() ? Numbers.convertToSubscript(core.getProximity() == Double.POSITIVE_INFINITY || core.getProximity() == Double.NEGATIVE_INFINITY ? core.getProximity() : Math.round(core.getProximity() * 10.0) / 10.0) + " " : "");
+                prefix = ChatColor.RED + " \u2715 " + ChatColor.GRAY + (core.showProximity() ? Numbers.convertToSubscript(core.getProximity() == Double.POSITIVE_INFINITY || core.getProximity() == Double.NEGATIVE_INFINITY ? core.getProximity() : Math.round(core.getProximity() * 10.0) / 10.0) + " " : "");
             } else {
                 prefix = ChatColor.RED + " \u2715 ";
             }
@@ -61,7 +61,7 @@ public class GameObjectiveScoreboardHandler {
                 } else if (destroyable.isTouched() && this.team != team) {
                     prefix = ChatColor.YELLOW + " " + destroyable.getPercent() + "% ";
                 } else if (this.team != team) {
-                    prefix = ChatColor.RED + " " + destroyable.getPercent() + "% " + ChatColor.RESET + (destroyable.showProximity() ? Numbers.convertToSubscript(destroyable.getProximity() == Double.POSITIVE_INFINITY || destroyable.getProximity() == Double.NEGATIVE_INFINITY ? destroyable.getProximity() : Math.round(destroyable.getProximity() * 10.0) / 10.0) + " " : "");
+                    prefix = ChatColor.RED + " " + destroyable.getPercent() + "% " + ChatColor.GRAY + (destroyable.showProximity() ? Numbers.convertToSubscript(destroyable.getProximity() == Double.POSITIVE_INFINITY || destroyable.getProximity() == Double.NEGATIVE_INFINITY ? destroyable.getProximity() : Math.round(destroyable.getProximity() * 10.0) / 10.0) + " " : "");
                 } else {
                     prefix = ChatColor.RED + " " + destroyable.getPercent() + "% ";
                 }
@@ -71,7 +71,7 @@ public class GameObjectiveScoreboardHandler {
                 } else if (destroyable.isTouched() && this.team != team) {
                     prefix = ChatColor.YELLOW + " " + destroyable.getPercent() + "% " + ChatColor.GRAY + destroyable.getBlocksBroken() + "/" + destroyable.getBlocksRequired() + " ";
                 } else if (this.team != team) {
-                    prefix = ChatColor.RED + " " + destroyable.getPercent() + "% " + ChatColor.GRAY + destroyable.getBlocksBroken() + "/" + destroyable.getBlocksRequired() + " " + ChatColor.RESET + (destroyable.showProximity() ? Numbers.convertToSubscript(destroyable.getProximity() == Double.POSITIVE_INFINITY || destroyable.getProximity() == Double.NEGATIVE_INFINITY ? destroyable.getProximity() : Math.round(destroyable.getProximity() * 10.0) / 10.0) + " " : "");
+                    prefix = ChatColor.RED + " " + destroyable.getPercent() + "% " + ChatColor.GRAY + destroyable.getBlocksBroken() + "/" + destroyable.getBlocksRequired() + " " + (destroyable.showProximity() ? Numbers.convertToSubscript(destroyable.getProximity() == Double.POSITIVE_INFINITY || destroyable.getProximity() == Double.NEGATIVE_INFINITY ? destroyable.getProximity() : Math.round(destroyable.getProximity() * 10.0) / 10.0) + " " : "");
                 } else {
                     prefix = ChatColor.RED + " " + destroyable.getPercent() + "% " + ChatColor.GRAY + destroyable.getBlocksBroken() + "/" + destroyable.getBlocksRequired() + " ";
                 }
@@ -81,7 +81,7 @@ public class GameObjectiveScoreboardHandler {
                 } else if (destroyable.isTouched() && this.team != team) {
                     prefix = ChatColor.YELLOW + " \u2733 ";
                 } else if (this.team != team) {
-                    prefix = ChatColor.RED + " \u2715 " + ChatColor.RESET + (destroyable.showProximity() ? Numbers.convertToSubscript(destroyable.getProximity() == Double.POSITIVE_INFINITY || destroyable.getProximity() == Double.NEGATIVE_INFINITY ? destroyable.getProximity() : Math.round(destroyable.getProximity() * 10.0) / 10.0) + " " : "");
+                    prefix = ChatColor.RED + " \u2715 " + ChatColor.GRAY + (destroyable.showProximity() ? Numbers.convertToSubscript(destroyable.getProximity() == Double.POSITIVE_INFINITY || destroyable.getProximity() == Double.NEGATIVE_INFINITY ? destroyable.getProximity() : Math.round(destroyable.getProximity() * 10.0) / 10.0) + " " : "");
                 } else {
                     prefix = ChatColor.RED + " \u2715 ";
                 }

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/wools/WoolObjective.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/wools/WoolObjective.java
@@ -149,14 +149,8 @@ public class WoolObjective implements GameObjective {
                         boolean oldState = this.touched;
                         this.touched = true;
                         if (touchMessage) {
-                            double newProx;
-                            if (location != null) {
-                                newProx = location.distance(place.getVector());
-                            } else {
-                                newProx = player.getLocation().toVector().distance(place.getVector());
-                            }
-                            if (!oldState || newProx < proximity) {
-                                proximity = newProx;
+                            if (!oldState) {
+                                proximity = Double.POSITIVE_INFINITY;
                             }
                         }
                         ObjectiveTouchEvent touchEvent = new ObjectiveTouchEvent(this, player, !oldState, touchMessage);
@@ -190,16 +184,8 @@ public class WoolObjective implements GameObjective {
                         }
                         boolean oldState = this.touched;
                         this.touched = true;
-                        if (touchMessage) {
-                            double newProx;
-                            if (location != null) {
-                                newProx = location.distance(place.getVector());
-                            } else {
-                                newProx = player.getLocation().toVector().distance(place.getVector());
-                            }
-                            if (!oldState || newProx < proximity) {
-                                proximity = newProx;
-                            }
+                        if (touchMessage && !oldState) {
+                                proximity = Double.POSITIVE_INFINITY;
                         }
                         ObjectiveTouchEvent touchEvent = new ObjectiveTouchEvent(this, player, !oldState, touchMessage);
                         Bukkit.getServer().getPluginManager().callEvent(touchEvent);
@@ -280,7 +266,7 @@ public class WoolObjective implements GameObjective {
             }
         }
     }
-    
+
     @EventHandler
     public void onEntityChangeBlock(EntityChangeBlockEvent event) {
         if (place.getBlock().equals(event.getBlock()))


### PR DESCRIPTION
Changes monument, destroyable and core proximity to gray
Changes wool untouched proximity to gray
Changes wool touched proximity to yellow
Wool touch changes proximity to infinity, placing a block sets it to the block (fixes #802)
Proximity command works again
Proximity command is only for observers
Proximity command only works on matches with scoring