### PR TITLE
Prevent cores' lava to be removed by water buckets

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/cores/CoreObjective.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/cores/CoreObjective.java
@@ -284,6 +284,9 @@ public class CoreObjective implements GameObjective {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onBlockFromTo(BlockFromToEvent event) {
+        if (lava.contains(event.getToBlock())){
+            event.setCancelled(true);
+        }
         if (!event.isCancelled()) {
             Block to = event.getToBlock();
             Block from = event.getBlock();
@@ -383,19 +386,19 @@ public class CoreObjective implements GameObjective {
 
     @EventHandler
     public void onBucketFill(PlayerBucketFillEvent event) {
-        if (region.contains(event.getBlockClicked().getLocation()) && event.getBlockClicked().getType() == Material.STATIONARY_LAVA)
+        if (lava.contains(event.getBlockClicked()))
             event.setCancelled(true);
     }
 
     @EventHandler
     public void onBucketEmpty(PlayerBucketEmptyEvent event) {
-        if (region.contains(event.getBlockClicked().getLocation()) && event.getBucket() == Material.LAVA_BUCKET)
+        if (lava.contains(event.getBlockClicked().getRelative(event.getBlockFace())))
             event.setCancelled(true);
     }
 
     @EventHandler
     public void onEntityChangeBlock(EntityChangeBlockEvent event) {
-        if (region.contains(event.getBlock().getLocation()) && event.getBlock().getType() == Material.STATIONARY_LAVA)
+        if (lava.contains(event.getBlock()))
             event.setCancelled(true);
     }
 }


### PR DESCRIPTION
It prevents buckets to be dumped inside lava (both water buckets and lava buckets)
As it is right now in cardinal, you can't place lava arround the core, and you can place water inside lava,
Additonally, you can place lava in the core region if you are clicking in a block outside of the region, but not against a block that's inside the core
Fixes #720