### PR TITLE
Remove a dropped item instead of cancelling an event for observers, fixes #528

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/observers/ObserverModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/observers/ObserverModule.java
@@ -435,7 +435,7 @@ public class ObserverModule implements Module {
     @EventHandler
     public void onPlayerDropItem(PlayerDropItemEvent event) {
         if (testObserver(event.getPlayer())) {
-            event.setCancelled(true);
+            event.getItemDrop().remove();
         }
     }
 


### PR DESCRIPTION
6159dc5 was undone somewhere in the teams branch