### PR TITLE
Prevent objectives being moved by pistons

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/cores/CoreObjective.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/cores/CoreObjective.java
@@ -35,6 +35,8 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockFormEvent;
 import org.bukkit.event.block.BlockFromToEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.BlockPistonExtendEvent;
+import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
@@ -303,6 +305,28 @@ public class CoreObjective implements GameObjective {
                         ObjectiveCompleteEvent compEvent = new ObjectiveCompleteEvent(this, null);
                         Bukkit.getServer().getPluginManager().callEvent(compEvent);
                     }
+                }
+            }
+        }
+    }
+     
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPistonPush(BlockPistonExtendEvent event) {
+        if (!event.isCancelled()) {
+            for (Block block : event.getBlocks()) {
+                if (getBlocks().contains(block)) {
+                    event.setCancelled(true);
+                }
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPistonRetract(BlockPistonRetractEvent event) {
+        if (!event.isCancelled() && event.isSticky()) {
+            for (Block block : event.getBlocks()) {
+                if (getBlocks().contains(block)) {
+                    event.setCancelled(true);
                 }
             }
         }

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/destroyable/DestroyableObjective.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/destroyable/DestroyableObjective.java
@@ -30,6 +30,8 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.BlockPistonExtendEvent;
+import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
@@ -265,6 +267,28 @@ public class DestroyableObjective implements GameObjective {
                     event.setCancelled(true);
                 } else {
                     ChatUtil.sendWarningMessage(event.getPlayer(), new LocalizedChatMessage(ChatConstant.ERROR_REPAIR_OBJECTIVE));
+                    event.setCancelled(true);
+                }
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPistonPush(BlockPistonExtendEvent event) {
+        if (!event.isCancelled()) {
+            for (Block block : event.getBlocks()) {
+                if (getBlocks().contains(block)) {
+                    event.setCancelled(true);
+                }
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPistonRetract(BlockPistonRetractEvent event) {
+        if (!event.isCancelled() && event.isSticky()) {
+            for (Block block : event.getBlocks()) {
+                if (getBlocks().contains(block)) {
                     event.setCancelled(true);
                 }
             }

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/wools/WoolObjective.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/wools/WoolObjective.java
@@ -24,12 +24,16 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPistonExtendEvent;
+import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -249,6 +253,38 @@ public class WoolObjective implements GameObjective {
         if (event.getBlock().equals(place.getBlock())) {
             event.setCancelled(true);
         }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPistonPush(BlockPistonExtendEvent event) {
+        if (!event.isCancelled()) {
+            if (event.getBlock().getRelative(event.getDirection()).equals(place.getBlock())) {
+                event.setCancelled(true);
+            } else {
+                for (Block block : event.getBlocks()) {
+                    if (block.equals(place.getBlock()) || block.equals(place.getBlock().getRelative(event.getDirection().getOppositeFace()))) {
+                        event.setCancelled(true);
+                    }
+                }
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPistonRetract(BlockPistonRetractEvent event) {
+        if (!event.isCancelled()) {
+            for (Block block : event.getBlocks()) {
+                if (block.equals(place.getBlock()) || block.equals(place.getBlock().getRelative(event.getDirection().getOppositeFace()))) {
+                    event.setCancelled(true);
+                }
+            }
+        }
+    }
+    
+    @EventHandler
+    public void onEntityChangeBlock(EntityChangeBlockEvent event) {
+        if (place.getBlock().equals(event.getBlock()))
+            event.setCancelled(true);
     }
 
     @EventHandler


### PR DESCRIPTION
fixes #787 
Prevents:
    Blocks getting pushed into/out of cores destroyables and wool monuments
    Sand or anvils blocking the wool monument