### PR TITLE
Prevent observers stopping the countdown if observers-ready is true

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/chat/ChatConstant.java
+++ b/src/main/java/in/twizmwaz/cardinal/chat/ChatConstant.java
@@ -101,6 +101,7 @@ public enum ChatConstant {
     ERROR_UNREADY_BEFORE_MATCH("error.unreadyBeforeMatch"),
     ERROR_TEAM_ALREADY_READY("error.teamAlreadyReady"),
     ERROR_TEAM_ALREADY_NOT_READY("error.teamAlreadyNotReady"),
+    ERROR_TEAM_CAN_NOT_UNREADY("error.teamCanNotUnready"),
     ERROR_INVALID_PAGE_NUMBER("error.invalidPageNumber"),
     ERROR_INVALID_ARGUMENTS("error.invalidArguments"),
     ERROR_TOO_FEW_ARGUMENTS("error.tooFewArguments"),

--- a/src/main/java/in/twizmwaz/cardinal/command/ReadyCommand.java
+++ b/src/main/java/in/twizmwaz/cardinal/command/ReadyCommand.java
@@ -33,7 +33,7 @@ public class ReadyCommand {
         if (!team.isPresent()) {
             throw new CommandException(ChatConstant.ERROR_TEAM_ABSENT.getMessage(ChatUtil.getLocale(sender)));
         }
-        if (team.get().isReady()) {
+        if (team.get().isReady() || (!Cardinal.getInstance().getConfig().getBoolean("observers-ready") && team.get().isObserver())) {
             throw new CommandException(ChatConstant.ERROR_TEAM_ALREADY_READY.getMessage(ChatUtil.getLocale(sender)));
         }
         team.get().setReady(true);
@@ -55,6 +55,9 @@ public class ReadyCommand {
         Optional<TeamModule> team = Teams.getTeamByPlayer((Player) sender);
         if (!team.isPresent()) {
             throw new CommandException(ChatConstant.ERROR_TEAM_ABSENT.getMessage(ChatUtil.getLocale(sender)));
+        }
+        if (!Cardinal.getInstance().getConfig().getBoolean("observers-ready") && team.get().isObserver()) {
+            throw new CommandException(ChatConstant.ERROR_TEAM_CAN_NOT_UNREADY.getMessage(ChatUtil.getLocale(sender)));
         }
         if (!team.get().isReady()) {
             throw new CommandException(ChatConstant.ERROR_TEAM_ALREADY_NOT_READY.getMessage(ChatUtil.getLocale(sender)));

--- a/src/main/resources/lang/en.xml
+++ b/src/main/resources/lang/en.xml
@@ -95,6 +95,7 @@
         <unreadyBeforeMatch>You must unready before the match starts.</unreadyBeforeMatch>
         <teamAlreadyReady>Your team is already ready.</teamAlreadyReady>
         <teamAlreadyNotReady>Your team is already not ready.</teamAlreadyNotReady>
+        <teamCanNotUnready>Your team can't unready.</teamCanNotUnready>
         <invalidPageNumber>Invalid page number specified! {0} total pages.</invalidPageNumber>
         <invalidArguments>Invalid arguments.</invalidArguments>
         <tooFewArguments>Too few arguments.</tooFewArguments>


### PR DESCRIPTION
If observers-ready is set to false, observer can't /ready (tram already ready) and can't /unready (team can't unready)

Fixes #711 