### PR TITLE
Update tdm and blitz scoreboard

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/blitz/BlitzBuilder.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/blitz/BlitzBuilder.java
@@ -17,7 +17,10 @@ public class BlitzBuilder implements ModuleBuilder {
         for (Element element : match.getDocument().getRootElement().getChildren("blitz")) {
             boolean broadcastLives = element.getChild("broadcastLives") == null || Numbers.parseBoolean(element.getChild("broadcastLives").getText());
             int lives = element.getChild("lives") == null ? 1 : Numbers.parseInt(element.getChild("lives").getText());
-            String title = element.getChildText("title") == null ? (match.getModules().getModule(Rage.class) != null ? "Blitz: Rage" : "Blitz") : element.getChildText("title");
+            String title = match.getModules().getModule(Rage.class) != null ? "Blitz: Rage" : "Blitz";
+            if (element.getChild("map") != null && element.getChild("map").getAttribute("game") != null){
+                title = element.getChild("map").getAttribute("game").getValue();
+            }
             result.add(new Blitz(title, broadcastLives, lives));
         }
         return result;

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/scoreboard/ScoreboardModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/scoreboard/ScoreboardModule.java
@@ -36,6 +36,7 @@ import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class ScoreboardModule implements Module {
@@ -111,20 +112,7 @@ public class ScoreboardModule implements Module {
             }
 
             if (Blitz.matchIsBlitz()) {
-                if (event.getOldTeam().isPresent() && !event.getOldTeam().get().isObserver()) {
-                    TeamModule team = event.getOldTeam().get();
-                    Team scoreboardTeam = scoreboard.getTeam(team.getId() + "-b");
-                    for (String entry : scoreboardTeam.getEntries()) {
-                        setScore(scoreboard.getObjective("scoreboard"), entry, team.size());
-                    }
-                }
-                if (event.getNewTeam().isPresent() && !event.getNewTeam().get().isObserver()) {
-                    TeamModule team = event.getNewTeam().get();
-                    Team scoreboardTeam = scoreboard.getTeam(team.getId() + "-b");
-                    for (String entry : scoreboardTeam.getEntries()) {
-                        setScore(scoreboard.getObjective("scoreboard"), entry, team.size());
-                    }
-                }
+                update();
             }
         }
     }
@@ -480,36 +468,41 @@ public class ScoreboardModule implements Module {
     public void renderTeamScore(ScoreModule score) {
         TeamModule teamModule = score.getTeam();
         Team team = scoreboard.getTeam(teamModule.getId() + "-s");
-        team.setPrefix(teamModule.getColor() + Strings.trimTo(teamModule.getName(), 0, 14));
-        team.setSuffix(Strings.trimTo(teamModule.getName(), 14, 30));
+        String fullName = score.getScore() + " " + teamModule.getCompleteName();
+        team.setPrefix(fullName.substring(0, 16));
+        team.setSuffix(fullName.substring(16, 32));
         if (team.getEntries().size() > 0) {
-            setScore(objective, new ArrayList<>(team.getEntries()).get(0), score.getScore());
+            setScore(objective, new ArrayList<>(team.getEntries()).get(0), currentScore);
         } else {
-            String name = teamModule.getColor() + "";
+            String name = ChatColor.RESET + "";
             while (used.contains(name)) {
-                name = teamModule.getColor() + name;
+                name = ChatColor.RESET + name;
             }
             team.addEntry(name);
-            setScore(objective, name, score.getScore());
+            setScore(objective, name, currentScore);
             used.add(name);
         }
+        currentScore++;
     }
 
     public void renderTeamBlitz(TeamModule teamModule) {
         Team team = scoreboard.getTeam(teamModule.getId() + "-b");
-        team.setPrefix(teamModule.getColor() + Strings.trimTo(teamModule.getName(), 0, 14));
-        team.setSuffix(Strings.trimTo(teamModule.getName(), 14, 30));
+        String fullName = teamModule.size() + " " + teamModule.getCompleteName();
+        team.setPrefix(fullName.substring(0, 16));
+        team.setSuffix(fullName.substring(16, 32));
         if (team.getEntries().size() > 0) {
-            setScore(objective, new ArrayList<>(team.getEntries()).get(0), teamModule.size());
+            String entry = new ArrayList<>(team.getEntries()).get(0);
+            setScore(objective, entry, scoreboard.getObjective("scoreboard").getScore(entry).getScore());
         } else {
-            String name = teamModule.getColor() + "";
+            String name = ChatColor.RESET + "";
             while (used.contains(name)) {
-                name = teamModule.getColor() + name;
+                name = ChatColor.RESET + name;
             }
             team.addEntry(name);
-            setScore(objective, name, teamModule.size());
+            setScore(objective, name, currentScore);
             used.add(name);
         }
+        currentScore++;
     }
 
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/scoreboard/ScoreboardModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/scoreboard/ScoreboardModule.java
@@ -474,9 +474,9 @@ public class ScoreboardModule implements Module {
         if (team.getEntries().size() > 0) {
             setScore(objective, new ArrayList<>(team.getEntries()).get(0), currentScore);
         } else {
-            String name = ChatColor.RESET + "";
+            String name = teamModule.getColor() + "";
             while (used.contains(name)) {
-                name = ChatColor.RESET + name;
+                name = teamModule.getColor() + name;
             }
             team.addEntry(name);
             setScore(objective, name, currentScore);
@@ -494,9 +494,9 @@ public class ScoreboardModule implements Module {
             String entry = new ArrayList<>(team.getEntries()).get(0);
             setScore(objective, entry, scoreboard.getObjective("scoreboard").getScore(entry).getScore());
         } else {
-            String name = ChatColor.RESET + "";
+            String name = teamModule.getColor() + "";
             while (used.contains(name)) {
-                name = ChatColor.RESET + name;
+                name = teamModule.getColor() + name;
             }
             team.addEntry(name);
             setScore(objective, name, currentScore);

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/scoreboard/ScoreboardModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/scoreboard/ScoreboardModule.java
@@ -36,7 +36,7 @@ import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 public class ScoreboardModule implements Module {
@@ -110,7 +110,6 @@ public class ScoreboardModule implements Module {
             if (event.getNewTeam().isPresent()) {
                 add(event.getNewTeam().get(), event.getPlayer());
             }
-
             if (Blitz.matchIsBlitz()) {
                 update();
             }
@@ -173,9 +172,7 @@ public class ScoreboardModule implements Module {
                     }
                     renderTeamTitle(team);
                     if (currentScore < getObjectiveSlots()) {
-                        String blank = getNextBlankSlot(used);
-                        setScore(objective, blank, currentScore);
-                        used.add(blank);
+                        setBlankSlot(currentScore);
                         currentScore++;
                     }
                 }
@@ -190,32 +187,27 @@ public class ScoreboardModule implements Module {
                 }
                 renderTeamTitle(prioritized);
                 if (currentScore < getObjectiveSlots()) {
-                    String blank = getNextBlankSlot(used);
-                    setScore(objective, blank, currentScore);
-                    used.add(blank);
+                    setBlankSlot(currentScore);
                     currentScore++;
                 }
             }
             if (ScoreModule.matchHasScoring()) {
-                for (ScoreModule score : GameHandler.getGameHandler().getMatch().getModules().getModules(ScoreModule.class)) {
-                    renderTeamScore(score);
+                if (currentScore != 0) {
+                    setBlankSlot(currentScore);
+                    currentScore++;
                 }
-            }
-            if (ScoreModule.matchHasMax()) {
-                setScore(objective, ChatColor.RED + "---- MAX ----", ScoreModule.max());
+                renderTeamScore();
             }
             if (Blitz.matchIsBlitz()) {
-                for (TeamModule team : Teams.getTeams()) {
-                    if (!team.isObserver()) {
-                        renderTeamBlitz(team);
-                    }
+                if (currentScore != 0) {
+                    setBlankSlot(currentScore);
+                    currentScore++;
                 }
+                renderTeamBlitz();
             }
             if (Scoreboards.getHills().size() > 0) {
                 if (!((getSpecificObjective() != null && getSpecificObjective().equals(HillObjective.class)) && !ScoreModule.matchHasScoring())) {
-                    String blank = getNextBlankSlot(used);
-                    setScore(objective, blank, currentHillScore);
-                    used.add(blank);
+                    setBlankSlot(currentHillScore);
                     currentHillScore--;
                 }
                 if (getSlots() < 16) {
@@ -237,12 +229,13 @@ public class ScoreboardModule implements Module {
         }
     }
 
-    public String getNextBlankSlot(List<String> used) {
+    public void setBlankSlot(int score) {
         String blank = " ";
         while (used.contains(blank)) {
             blank += " ";
         }
-        return blank;
+        setScore(objective, blank, score);
+        used.add(blank);
     }
 
     public void setScore(Objective objective, String string, int score) {
@@ -317,6 +310,7 @@ public class ScoreboardModule implements Module {
     }
 
     public String getDisplayTitle() {
+        String displayTitle = "";
         boolean hasObjectives = false;
         for (GameObjective obj : GameHandler.getGameHandler().getMatch().getModules().getModules(GameObjective.class)) {
             if (obj.showOnScoreboard()) {
@@ -327,23 +321,29 @@ public class ScoreboardModule implements Module {
         if (hasObjectives) {
             if (objective != null) {
                 if (objective.equals(WoolObjective.class)) {
-                    return ChatColor.AQUA + "Wools";
+                    displayTitle = "Wools";
                 } else if (objective.equals(CoreObjective.class)) {
-                    return ChatColor.AQUA + "Cores";
+                    displayTitle = "Cores";
                 } else if (objective.equals(DestroyableObjective.class)) {
-                    return ChatColor.AQUA + "Monuments";
+                    displayTitle = "Monuments";
                 } else if (objective.equals(HillObjective.class)) {
-                    return ChatColor.AQUA + "Hills";
+                    displayTitle = "Hills";
                 }
             } else {
-                return ChatColor.AQUA + "Objectives";
+                displayTitle = "Objectives";
             }
-        } else if (GameHandler.getGameHandler().getMatch().getModules().getModule(Blitz.class) != null) {
-            return ChatColor.AQUA + GameHandler.getGameHandler().getMatch().getModules().getModule(Blitz.class).getTitle();
-        } else if (ScoreModule.matchHasScoring()) {
-            return ChatColor.AQUA + "Scores";
         }
-        return ChatColor.RED + "" + ChatColor.BOLD + "Invalid";
+        if (ScoreModule.matchHasScoring()) {
+            displayTitle = displayTitle.equals("") || displayTitle.equals("Hills") ? "Scores" : "Objectives";
+        }
+        if (Blitz.matchIsBlitz()) {
+            String blitzTitle = GameHandler.getGameHandler().getMatch().getModules().getModule(Blitz.class).getTitle();
+            displayTitle = (blitzTitle.equals("Blitz") || blitzTitle.equals("Blitz: Rage")) ? (displayTitle.equals("") ? blitzTitle : "Players Remaining") : blitzTitle;
+        }
+        if (displayTitle.equals("")) {
+            return ChatColor.RED + "" + ChatColor.BOLD + "Invalid";
+        }
+        return ChatColor.AQUA + displayTitle;
     }
 
     public Class getSpecificObjective() {
@@ -465,44 +465,70 @@ public class ScoreboardModule implements Module {
         currentScore++;
     }
 
-    public void renderTeamScore(ScoreModule score) {
-        TeamModule teamModule = score.getTeam();
-        Team team = scoreboard.getTeam(teamModule.getId() + "-s");
-        String fullName = score.getScore() + " " + teamModule.getCompleteName();
-        team.setPrefix(fullName.substring(0, 16));
-        team.setSuffix(fullName.substring(16, 32));
-        if (team.getEntries().size() > 0) {
-            setScore(objective, new ArrayList<>(team.getEntries()).get(0), currentScore);
-        } else {
-            String name = teamModule.getColor() + "";
-            while (used.contains(name)) {
-                name = teamModule.getColor() + name;
+    public void renderTeamScore() {
+        List<String> fullNames = new ArrayList<>();
+        for (ScoreModule score : GameHandler.getGameHandler().getMatch().getModules().getModules(ScoreModule.class)){
+            if (score.getMax() != 0){
+                fullNames.add(score.getScore() + "" + ChatColor.DARK_GRAY + "/" + ChatColor.GRAY + score.getMax() + " " + score.getTeam().getCompleteName());
+            } else {
+                fullNames.add(score.getScore() + " " + score.getTeam().getCompleteName());
             }
-            team.addEntry(name);
-            setScore(objective, name, currentScore);
-            used.add(name);
         }
-        currentScore++;
+        java.util.Collections.sort(fullNames, new Comparator<String>(){
+            public int compare(String str1, String str2){
+                int int1 = Integer.parseInt((str1.contains("/") ? str1.split("\u00a7",2) : str1.split(" ",2))[0]);
+                int int2 = Integer.parseInt((str2.contains("/") ? str2.split("\u00a7",2) : str2.split(" ",2))[0]);
+                return int1 - int2;
+            }
+        });
+        for (int i = 0; i < fullNames.size(); i++) {
+            String teamCompleteName[] = fullNames.get(i).split(" ",2);
+            String teamName = teamCompleteName[1].substring(2);
+            Team team = scoreboard.getTeam(Teams.getTeamByName(teamName).get().getId() + "-s");
+            team.setPrefix(Strings.trimTo(fullNames.get(i), 0, 16));
+            team.setSuffix(Strings.trimTo(fullNames.get(i), 16, 32));
+            if (team.getEntries().size() > 0) {
+                setScore(objective, new ArrayList<>(team.getEntries()).get(0), currentScore);
+            } else {
+                String name = Teams.getTeamByName(teamName).get().getColor() + "";
+                while (used.contains(name)) {
+                    name = Teams.getTeamByName(teamName).get().getColor() + name;
+                }
+                team.addEntry(name);
+                setScore(objective, name, currentScore);
+                used.add(name);
+            }
+            currentScore++;
+        }
     }
 
-    public void renderTeamBlitz(TeamModule teamModule) {
-        Team team = scoreboard.getTeam(teamModule.getId() + "-b");
-        String fullName = teamModule.size() + " " + teamModule.getCompleteName();
-        team.setPrefix(fullName.substring(0, 16));
-        team.setSuffix(fullName.substring(16, 32));
-        if (team.getEntries().size() > 0) {
-            String entry = new ArrayList<>(team.getEntries()).get(0);
-            setScore(objective, entry, scoreboard.getObjective("scoreboard").getScore(entry).getScore());
-        } else {
-            String name = teamModule.getColor() + "";
-            while (used.contains(name)) {
-                name = teamModule.getColor() + name;
+    public void renderTeamBlitz() {
+        List<String> fullNames = new ArrayList<>();
+        for (TeamModule team : Teams.getTeams()) {
+            if (!team.isObserver()) {
+                fullNames.add(team.size() + " " + team.getCompleteName());
             }
-            team.addEntry(name);
-            setScore(objective, name, currentScore);
-            used.add(name);
         }
-        currentScore++;
+        java.util.Collections.sort(fullNames);
+        for (int i = 0; i < fullNames.size(); i++) {
+            String teamCompleteName[] = fullNames.get(i).split(" ",2);
+            String teamName = teamCompleteName[1].substring(2);
+            Team team = scoreboard.getTeam(Teams.getTeamByName(teamName).get().getId() + "-b");
+            team.setPrefix(Strings.trimTo(fullNames.get(i), 0, 16));
+            team.setSuffix(Strings.trimTo(fullNames.get(i), 16, 32));
+            if (team.getEntries().size() > 0) {
+                setScore(objective, new ArrayList<>(team.getEntries()).get(0), currentScore);
+            } else {
+                String name = Teams.getTeamByName(teamName).get().getColor() + "";
+                while (used.contains(name)) {
+                    name = Teams.getTeamByName(teamName).get().getColor() + name;
+                }
+                team.addEntry(name);
+                setScore(objective, name, currentScore);
+                used.add(name);
+            }
+            currentScore++;
+        }
     }
 
 }


### PR DESCRIPTION
What thomblr did:
  -  Display TDM and Blitz scoreboard using "number + team" ![0 Red Team](http://i.imgur.com/whYdIQl.png)
  -  [Displays TDM and Blitz ontop of other objectives (ctw/dtc/something)](http://i.imgur.com/PcuuaQM.png)

What I added:
  -  [Sorts blitz and tdm scoreboards, the team with the most score goes first](https://i.gyazo.com/331df7c679a77287d57ee82f982c9c86.png)
  -  TDM max used to be ![--- MAX ---  250](http://i.imgur.com/LB9aGpp.png), now it's ![10/250 Blue Team](http://i.imgur.com/Vsq8l0N.png)
  -  [Add a blank name between other objectives and TDM/Blitz](http://i.imgur.com/BkMd4bT.png)
  -  Fixed scoreboard titles

Scoreboard titles now:
  -  There are 4 objectives, Wools, Cores, Monuments, and Hills
  -  There is Score , or Blitz (Blitz, Blitz: Rage, or Custom name)
  -  If there is only 1 type of objective, the name is used
  -  If there are more than 1 diferent type of objectives, "Objectives" is used
  -  If the match only has TDM or TDM + hills, "Score" is used, if it has any other objective, "Objectives" is used
  -  If there is a Blitz custom name it will prioritize it always
  -  If Blitz is the only gamemode it uses "Blitz, Blitz: Rage. the custom set one". if it has other objectives, the scoreboard will be called "Remaining Players" (it's what OCN uses)
