### PR TITLE
Use proper default fly speed

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/util/Players.java
+++ b/src/main/java/in/twizmwaz/cardinal/util/Players.java
@@ -27,7 +27,7 @@ public class Players {
         player.setExp(0);
         player.setPotionParticles(true);
         player.setWalkSpeed(0.2F);
-        player.setFlySpeed(0.2F);
+        player.setFlySpeed(0.1F);
     }
 
     public static double getSnowflakeMultiplier(OfflinePlayer player) {


### PR DESCRIPTION
Atm when using cardinal you fly at double the speed, and it's annoying for building etc