### PR TITLE
Fix Bossbar not dissapearing

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/bossBar/BossBar.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/bossBar/BossBar.java
@@ -52,7 +52,7 @@ public class BossBar implements Module {
         }
         if (wither != null) {
             wither.name = checkMessageLength(message.getMessage(player.getLocale()));
-            wither.health = percent * 100F / wither.getMaxHealth() < 1 ? 1 : percent * 100F / wither.getMaxHealth();
+            wither.health = percent * 100F / wither.getMaxHealth();
         }
         updateWither(wither, player);
     }

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/monumentModes/MonumentModes.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/monumentModes/MonumentModes.java
@@ -103,11 +103,12 @@ public class MonumentModes implements TaskedModule {
                     showBefore = mode.getShowBefore();
                 }
             }
-            if (timeBeforeMode > 0 && timeBeforeMode < showBefore && name != null) {
+            if (timeBeforeMode > 0 && timeBeforeMode <= showBefore && name != null) {
                 int percent = (int) (timeBeforeMode * 100F) / showBefore;
+                if (timeBeforeMode <= 1) percent = 0;
                 BossBar.sendGlobalBossBar(new UnlocalizedChatMessage(ChatColor.RED + "{0}", new LocalizedChatMessage(ChatConstant.UI_MODE_IN_TIME, new UnlocalizedChatMessage(ChatColor.RED + name + ChatColor.AQUA)), ((timeBeforeMode) == 1 ? new LocalizedChatMessage(ChatConstant.UI_SECOND, ChatColor.DARK_AQUA + "1" + ChatColor.AQUA) : new LocalizedChatMessage(ChatConstant.UI_SECONDS, ChatColor.DARK_AQUA + String.valueOf(timeBeforeMode) + ChatColor.AQUA))), percent);
             }
-            if (timeBeforeMode < 0 || (TimeLimit.getMatchTimeLimit() == 0 && (timeBeforeMode > showBefore || timeBeforeMode <= 0))) {
+            if (timeBeforeMode <= 0 || (TimeLimit.getMatchTimeLimit() == 0 && (timeBeforeMode > showBefore || timeBeforeMode <= 0))) {
                 BossBar.delete();
             }
         }

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/timeNotifications/TimeNotifications.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/timeNotifications/TimeNotifications.java
@@ -81,6 +81,7 @@ public class TimeNotifications implements TaskedModule {
             } else if (TimeLimit.getMatchTimeLimit() > 0) {
                 int timeLeft = ((TimeLimit.getMatchTimeLimit() - (int) MatchTimer.getTimeInSeconds()));
                 int percent = (int) ((100F * timeLeft) / TimeLimit.getMatchTimeLimit());
+                if (percent == 0) percent = 1;
                 BossBar.sendGlobalBossBar(new UnlocalizedChatMessage(ChatColor.AQUA + "{0} " + ChatUtil.getTimerColor(timeRemaining) + "{1}", new LocalizedChatMessage(ChatConstant.UI_TIMER), new UnlocalizedChatMessage(Strings.formatTime(timeRemaining + 1))), percent);
             }
             if (nextTimeMessage >= timeRemaining) {


### PR DESCRIPTION
reverts 7b9ec40 and makes a more localized fix, instead of forcing all withers to have atleast 1 health, because it messed up with bossbar.delete()