### PR TITLE
Scoreboard update

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/scoreboard/GameObjectiveScoreboardHandler.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/scoreboard/GameObjectiveScoreboardHandler.java
@@ -34,70 +34,71 @@ public class GameObjectiveScoreboardHandler {
         if (objective instanceof WoolObjective) {
             WoolObjective wool = (WoolObjective) objective;
             if (wool.isComplete()) {
-                prefix = MiscUtil.convertDyeColorToChatColor(wool.getColor()) + " \u2B1B ";
+                prefix = MiscUtil.convertDyeColorToChatColor(wool.getColor()) + " \u2B1B";
             } else if (wool.isTouched() && (this.team == team || team.isObserver())) {
-                prefix = MiscUtil.convertDyeColorToChatColor(wool.getColor()) + " \u2592 " + (wool.showProximity() ? ChatColor.YELLOW + Numbers.convertToSubscript(wool.getProximity() == Double.POSITIVE_INFINITY || wool.getProximity() == Double.NEGATIVE_INFINITY ? wool.getProximity() : Math.round(wool.getProximity() * 10.0) / 10.0) + " " : "");
+                prefix = MiscUtil.convertDyeColorToChatColor(wool.getColor()) + " \u2592 " + (wool.showProximity() ? ChatColor.YELLOW + Numbers.convertToSubscript(wool.getProximity() == Double.POSITIVE_INFINITY || wool.getProximity() == Double.NEGATIVE_INFINITY ? wool.getProximity() : Math.round(wool.getProximity() * 10.0) / 10.0) : "");
             } else if (this.team == team || team.isObserver()) {
-                prefix = MiscUtil.convertDyeColorToChatColor(wool.getColor()) + " \u2B1C " + (wool.showProximity() ? ChatColor.GRAY + Numbers.convertToSubscript(wool.getProximity() == Double.POSITIVE_INFINITY || wool.getProximity() == Double.NEGATIVE_INFINITY ? wool.getProximity() : Math.round(wool.getProximity() * 10.0) / 10.0) + " " : "");
+                prefix = MiscUtil.convertDyeColorToChatColor(wool.getColor()) + " \u2B1C " + (wool.showProximity() ? ChatColor.GRAY + Numbers.convertToSubscript(wool.getProximity() == Double.POSITIVE_INFINITY || wool.getProximity() == Double.NEGATIVE_INFINITY ? wool.getProximity() : Math.round(wool.getProximity() * 10.0) / 10.0) : "");
             } else {
-                prefix = MiscUtil.convertDyeColorToChatColor(wool.getColor()) + " \u2B1C ";
+                prefix = MiscUtil.convertDyeColorToChatColor(wool.getColor()) + " \u2B1C";
             }
         } else if (objective instanceof CoreObjective) {
             CoreObjective core = (CoreObjective) objective;
             if (core.isComplete()) {
-                prefix = ChatColor.GREEN + " \u2714 ";
+                prefix = ChatColor.GREEN + " \u2714";
             } else if (core.isTouched() && this.team != team) {
-                prefix = ChatColor.YELLOW + " \u2733 ";
+                prefix = ChatColor.YELLOW + " \u2733";
             } else if (this.team != team) {
-                prefix = ChatColor.RED + " \u2715 " + ChatColor.GRAY + (core.showProximity() ? Numbers.convertToSubscript(core.getProximity() == Double.POSITIVE_INFINITY || core.getProximity() == Double.NEGATIVE_INFINITY ? core.getProximity() : Math.round(core.getProximity() * 10.0) / 10.0) + " " : "");
+                prefix = ChatColor.RED + " \u2715 " + ChatColor.GRAY + (core.showProximity() ? Numbers.convertToSubscript(core.getProximity() == Double.POSITIVE_INFINITY || core.getProximity() == Double.NEGATIVE_INFINITY ? core.getProximity() : Math.round(core.getProximity() * 10.0) / 10.0) : "");
             } else {
-                prefix = ChatColor.RED + " \u2715 ";
+                prefix = ChatColor.RED + " \u2715";
             }
         } else if (objective instanceof DestroyableObjective) {
             DestroyableObjective destroyable = (DestroyableObjective) objective;
             if (destroyable.showPercent()) {
                 if (destroyable.isComplete()) {
-                    prefix = ChatColor.GREEN + " " + destroyable.getPercent() + "% ";
+                    prefix = ChatColor.GREEN + " " + destroyable.getPercent() + "%";
                 } else if (destroyable.isTouched() && this.team != team) {
                     prefix = ChatColor.YELLOW + " " + destroyable.getPercent() + "% ";
                 } else if (this.team != team) {
-                    prefix = ChatColor.RED + " " + destroyable.getPercent() + "% " + ChatColor.GRAY + (destroyable.showProximity() ? Numbers.convertToSubscript(destroyable.getProximity() == Double.POSITIVE_INFINITY || destroyable.getProximity() == Double.NEGATIVE_INFINITY ? destroyable.getProximity() : Math.round(destroyable.getProximity() * 10.0) / 10.0) + " " : "");
+                    prefix = ChatColor.RED + " " + destroyable.getPercent() + "% " + ChatColor.GRAY + (destroyable.showProximity() ? Numbers.convertToSubscript(destroyable.getProximity() == Double.POSITIVE_INFINITY || destroyable.getProximity() == Double.NEGATIVE_INFINITY ? destroyable.getProximity() : Math.round(destroyable.getProximity() * 10.0) / 10.0) : "");
                 } else {
-                    prefix = ChatColor.RED + " " + destroyable.getPercent() + "% ";
+                    prefix = ChatColor.RED + " " + destroyable.getPercent() + "%";
                 }
             } else if (team.isObserver()) {
                 if (destroyable.isComplete()) {
-                    prefix = ChatColor.GREEN + " " + destroyable.getPercent() + "% " + ChatColor.GRAY + destroyable.getBlocksBroken() + "/" + destroyable.getBlocksRequired() + " ";
-                } else if (destroyable.isTouched() && this.team != team) {
-                    prefix = ChatColor.YELLOW + " " + destroyable.getPercent() + "% " + ChatColor.GRAY + destroyable.getBlocksBroken() + "/" + destroyable.getBlocksRequired() + " ";
-                } else if (this.team != team) {
-                    prefix = ChatColor.RED + " " + destroyable.getPercent() + "% " + ChatColor.GRAY + destroyable.getBlocksBroken() + "/" + destroyable.getBlocksRequired() + " " + (destroyable.showProximity() ? Numbers.convertToSubscript(destroyable.getProximity() == Double.POSITIVE_INFINITY || destroyable.getProximity() == Double.NEGATIVE_INFINITY ? destroyable.getProximity() : Math.round(destroyable.getProximity() * 10.0) / 10.0) + " " : "");
+                    prefix = ChatColor.GREEN + " " + destroyable.getPercent() + "% " + ChatColor.GRAY + destroyable.getBlocksBroken() + "/" + destroyable.getBlocksRequired();
+                } else if (destroyable.isTouched()) {
+                    prefix = ChatColor.YELLOW + " " + destroyable.getPercent() + "% " + ChatColor.GRAY + destroyable.getBlocksBroken() + "/" + destroyable.getBlocksRequired();
                 } else {
-                    prefix = ChatColor.RED + " " + destroyable.getPercent() + "% " + ChatColor.GRAY + destroyable.getBlocksBroken() + "/" + destroyable.getBlocksRequired() + " ";
+                    prefix = " " + ChatColor.RED + destroyable.getPercent() + "% " + ChatColor.GRAY + destroyable.getBlocksBroken() + "/" + destroyable.getBlocksRequired() + (destroyable.showProximity() ? " " + Numbers.convertToSubscript(destroyable.getProximity() == Double.POSITIVE_INFINITY || destroyable.getProximity() == Double.NEGATIVE_INFINITY ? destroyable.getProximity() : Math.round(destroyable.getProximity() * 10.0) / 10.0) : "");
+                    if (destroyable.showProximity() && prefix.length() > 16) {
+                        prefix = " " + prefix.split(" ")[1] + " " +ChatColor.GRAY  + prefix.split(" ")[3];
+                    }
                 }
             } else {
                 if (destroyable.isComplete()) {
-                    prefix = ChatColor.GREEN + " \u2714 ";
+                    prefix = ChatColor.GREEN + " \u2714";
                 } else if (destroyable.isTouched() && this.team != team) {
-                    prefix = ChatColor.YELLOW + " \u2733 ";
+                    prefix = ChatColor.YELLOW + " \u2733";
                 } else if (this.team != team) {
-                    prefix = ChatColor.RED + " \u2715 " + ChatColor.GRAY + (destroyable.showProximity() ? Numbers.convertToSubscript(destroyable.getProximity() == Double.POSITIVE_INFINITY || destroyable.getProximity() == Double.NEGATIVE_INFINITY ? destroyable.getProximity() : Math.round(destroyable.getProximity() * 10.0) / 10.0) + " " : "");
+                    prefix = ChatColor.RED + " \u2715 " + ChatColor.GRAY + (destroyable.showProximity() ? Numbers.convertToSubscript(destroyable.getProximity() == Double.POSITIVE_INFINITY || destroyable.getProximity() == Double.NEGATIVE_INFINITY ? destroyable.getProximity() : Math.round(destroyable.getProximity() * 10.0) / 10.0) : "");
                 } else {
-                    prefix = ChatColor.RED + " \u2715 ";
+                    prefix = ChatColor.RED + " \u2715";
                 }
             }
         } else if (objective instanceof HillObjective) {
             HillObjective hill = (HillObjective) objective;
             if (hill.isComplete()) {
-                prefix = ChatColor.RESET + " \u29BF" + (hill.getTeam() != null ? hill.getTeam().getColor() : "") + " ";
+                prefix = ChatColor.RESET + " \u29BF" + (hill.getTeam() != null ? hill.getTeam().getColor() : "");
             } else if (hill.isTouched()) {
                 if (hill.showProgress()) {
-                    prefix = ChatColor.RESET + " " + (hill.getCapturingTeam() != null ? hill.getCapturingTeam().getColor() : ChatColor.RESET) + "" + hill.getPercent() + "%" + (hill.getTeam() != null ? hill.getTeam().getColor() : "") + " ";
+                    prefix = ChatColor.RESET + " " + (hill.getCapturingTeam() != null ? hill.getCapturingTeam().getColor() : ChatColor.RESET) + "" + hill.getPercent() + "%" + (hill.getTeam() != null ? hill.getTeam().getColor() : "");
                 } else {
-                    prefix = ChatColor.RESET + " \u29BF" + (hill.getTeam() != null ? hill.getTeam().getColor() : "") + " ";
+                    prefix = ChatColor.RESET + " \u29BF" + (hill.getTeam() != null ? hill.getTeam().getColor() : "");
                 }
             } else {
-                prefix = ChatColor.RESET + " \u29BE ";
+                prefix = ChatColor.RESET + " \u29BE";
             }
         } else {
             prefix = " ";
@@ -108,5 +109,53 @@ public class GameObjectiveScoreboardHandler {
         return prefix;
     }
 
+    public String getCompactPrefix(TeamModule team) {
+        String prefix;
+        if (objective instanceof WoolObjective) {
+            WoolObjective wool = (WoolObjective) objective;
+            if (wool.isComplete()) {
+                prefix = MiscUtil.convertDyeColorToChatColor(wool.getColor()) + " \u2B1B ";
+            } else if (wool.isTouched() && (this.team == team || team.isObserver())) {
+                prefix = MiscUtil.convertDyeColorToChatColor(wool.getColor()) + " \u2592 ";
+            } else {
+                prefix = MiscUtil.convertDyeColorToChatColor(wool.getColor()) + " \u2B1C ";
+            }
+        } else if (objective instanceof CoreObjective) {
+            CoreObjective core = (CoreObjective) objective;
+            if (core.isComplete()) {
+                prefix = ChatColor.GREEN + " \u2714 ";
+            } else if (core.isTouched() && this.team != team) {
+                prefix = ChatColor.YELLOW + " \u2733 ";
+            } else {
+                prefix = ChatColor.RED + " \u2715 ";
+            }
+        } else if (objective instanceof DestroyableObjective) {
+            DestroyableObjective destroyable = (DestroyableObjective) objective;
+            if (destroyable.isComplete()) {
+                prefix = ChatColor.GREEN + " \u2714 ";
+            } else if (destroyable.isTouched()) {
+                if (team.isObserver()) {
+                    prefix = ChatColor.YELLOW + " " + destroyable.getPercent() + "% ";
+                } else if (destroyable.showPercent()) {
+                    if (this.team == team) {
+                        prefix = ChatColor.YELLOW + " " + destroyable.getPercent() + "% ";
+                    } else {
+                        prefix = ChatColor.RED + " " + destroyable.getPercent() + "% ";
+                    }
+                } else {
+                    if (this.team == team) {
+                        prefix = ChatColor.YELLOW + " \u2733 ";
+                    } else {
+                        prefix = ChatColor.RED + " \u2715 ";
+                    }
+                }
+            } else {
+                prefix = ChatColor.RED + " \u2715 ";
+            }
+        } else {
+            prefix = "";
+        }
+        return prefix;
+    }
 
 }


### PR DESCRIPTION
This scoreboard fixes issues with Revenge TE, Ender Blast, and Battle ecliptica II
 Closes: #119(partially), #717 , #767 & #707 

What it does:
 - It gets rid of the suffix, and uses only Prefix and player name
 - The last space was moved from the prefix to the player name to save a character
 - Created a new "GetCompactPrefix" that returns the minimum characters it can
 - In compact objectives, the player name will always end with a "§", and the suffix will always start with
the color that was before the player name, that way you save up another character
 - Team titles no longer use prefix or suffix, they just use the player name

about #119: the match doesn't end, but the scoreboard gets updated