### PR TITLE
Prevent pistons moving blocks into regions

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/appliedRegion/type/BlockEventRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/appliedRegion/type/BlockEventRegion.java
@@ -198,9 +198,24 @@ public class BlockEventRegion extends AppliedRegion {
 
     @EventHandler
     public void onBlockPistonExtend(BlockPistonExtendEvent event) {
+        if (region.contains(event.getBlock().getRelative(event.getDirection()).getLocation().toVector()) && filter.evaluate(event.getBlock().getRelative(event.getDirection()), event).equals(FilterState.DENY)) {
+            event.setCancelled(true);
+        } else {
+            for (Block block : event.getBlocks()) {
+                if ((region.contains(block.getLocation().toVector()) && filter.evaluate(block, event).equals(FilterState.DENY)) || (region.contains(block.getRelative(event.getDirection()).getLocation().toVector()) && filter.evaluate(block.getRelative(event.getDirection()), event).equals(FilterState.DENY))) {
+                    event.setCancelled(true);
+                    break;
+                }
+            }
+        }
+    }
+
+    @EventHandler
+    public void onBlockPistonRetract(BlockPistonRetractEvent event) {
         for (Block block : event.getBlocks()) {
-            if (region.contains(block.getRelative(event.getDirection()).getLocation().toVector()) && filter.evaluate(block, event).equals(FilterState.DENY)) {
+            if ((region.contains(block.getLocation().toVector()) && filter.evaluate(block, event).equals(FilterState.DENY)) || (region.contains(block.getRelative(event.getDirection()).getLocation().toVector()) && filter.evaluate(block.getRelative(event.getDirection()), event).equals(FilterState.DENY))) {
                 event.setCancelled(true);
+                break;
             }
         }
     }

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/appliedRegion/type/BlockPlaceRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/appliedRegion/type/BlockPlaceRegion.java
@@ -53,9 +53,14 @@ public class BlockPlaceRegion extends AppliedRegion {
 
     @EventHandler
     public void onBlockPistonExtend(BlockPistonExtendEvent event) {
-        for (Block block : event.getBlocks()) {
-            if (region.contains(block.getRelative(event.getDirection()).getLocation().toVector()) && filter.evaluate(block, event).equals(FilterState.DENY)) {
-                event.setCancelled(true);
+        if (region.contains(event.getBlock().getRelative(event.getDirection()).getLocation().toVector()) && filter.evaluate(event.getBlock().getRelative(event.getDirection()), event).equals(FilterState.DENY)) {
+            event.setCancelled(true);
+        } else {
+            for (Block block : event.getBlocks()) {
+                if (region.contains(block.getRelative(event.getDirection()).getLocation().toVector()) && filter.evaluate(block.getRelative(event.getDirection()), event).equals(FilterState.DENY)) {
+                    event.setCancelled(true);
+                    break;
+                }
             }
         }
     }
@@ -63,8 +68,9 @@ public class BlockPlaceRegion extends AppliedRegion {
     @EventHandler
     public void onBlockPistonRetract(BlockPistonRetractEvent event) {
         for (Block block : event.getBlocks()) {
-            if (region.contains(block.getRelative(event.getDirection()).getLocation().toVector()) && filter.evaluate(block, event).equals(FilterState.DENY)) {
+            if (region.contains(block.getRelative(event.getDirection()).getLocation().toVector()) && filter.evaluate(block.getRelative(event.getDirection()), event).equals(FilterState.DENY)) {
                 event.setCancelled(true);
+                break;
             }
         }
     }


### PR DESCRIPTION
fixes #715 
it also prevents blocks being retracted into void regions, and should pretty much fix all issues regarding pistons and regions
(tested in GDIII and blocks don't get pushed out of the map into the void)