### PR TITLE
Add Admidistrator rank

### DIFF
--- a/src/main/resources/ranks.xml
+++ b/src/main/resources/ranks.xml
@@ -35,4 +35,8 @@
         <permission>cardinal.punish.mute</permission>
         <permission>minecraft.command.pardon</permission>
     </rank>
+      <rank name="Administrator" staff="true" flair="`6❖" parent="Moderator">
+        <permission>cardinal.*</permission>
+        <permission>minecraft.command.pardon</permission>
+    </rank>
 </ranks>


### PR DESCRIPTION
Adds the rank of administrator to allow server owners not to have to op users. Has all cardinal permissions, as I believe wildcards work? They worked in testing at least.

This has been talked about on the issues page a bit, so I thought I might as well add it as it is currently existing on my server anyway. It's an alternative to opping people and having them run wild over all the server commands.