### PR TITLE
Add material as filter case

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/filter/FilterModuleBuilder.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/filter/FilterModuleBuilder.java
@@ -84,6 +84,8 @@ public class FilterModuleBuilder implements ModuleBuilder {
                 return new HoldingFilter(new ItemFilterParser(element));
             case "kill-streak":
                 return new KillStreakFilter(new KillstreakFilterParser(element));
+            case "material":
+                return new BlockFilter(new BlockFilterParser(element));
             case "mob":
                 return new MobFilter(new MobFilterParser(element));
             case "objective":


### PR DESCRIPTION
in 1.4.0 <block> was replaced by <material>, in cardinal we shouldn't remove block, as it doesn't support multiple prot., but we should support material