### PR TITLE
Fix inventory view not opening if the display name is too big

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/observers/ObserverModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/observers/ObserverModule.java
@@ -380,7 +380,7 @@ public class ObserverModule implements Module {
     }
 
     public Inventory getFakeInventory(Player player, String locale) {
-        Inventory inventory = Bukkit.createInventory(null, 45, player.getDisplayName());
+        Inventory inventory = Bukkit.createInventory(null, 45, player.getDisplayName().length() > 32 ? Teams.getTeamColorByPlayer(player) + player.getName() : player.getDisplayName());
         inventory.setItem(0, player.getInventory().getHelmet());
         inventory.setItem(1, player.getInventory().getChestplate());
         inventory.setItem(2, player.getInventory().getLeggings());


### PR DESCRIPTION
The max title length for an inventory title is 32 characters, if the player's name + ranks is bigger than 32 characters, it will throw an exception and not open the inventory