### PR TITLE
Fix tool repair module merging items that shouldn't merge

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/toolRepair/ToolRepair.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/toolRepair/ToolRepair.java
@@ -27,36 +27,24 @@ public class ToolRepair implements Module {
     public void onPlayerPickupItem(PlayerPickupItemEvent event) {
         if (!event.isCancelled()) {
             ItemStack item1 = event.getItem().getItemStack();
-            if (materials.contains(item1.getType())) {
-                if (event.getPlayer().getInventory().contains(item1.getType())) {
-                    ItemStack toRepair = null;
-                    boolean itemsMatch = false;
-                    for (ItemStack item2 : event.getPlayer().getInventory().getContents()) {
-                        if (item2 != null) {
-                            if (item1.getType() == item2.getType()) {
-                                if (item1.getEnchantments() != null && item2.getEnchantments() != null) {
-                                    if (item1.getEnchantments().equals(item2.getEnchantments())) {
-                                        itemsMatch = true;
-                                    }
-                                } else {
-                                    if (item1.getEnchantments() == null && item2.getEnchantments() == null) {
-                                        itemsMatch = true;
-                                    }
-                                }
-                                if (itemsMatch) {
-                                    toRepair = item2;
-                                }
-                            }
-                        }
-                    }
-                    if (itemsMatch) {
+            if (materials.contains(item1.getType()) && event.getPlayer().getInventory().contains(item1.getType())) {
+                for (ItemStack item2 : event.getPlayer().getInventory().getContents()) {
+                    if (item2 != null && toMaxDurability(item1).equals(toMaxDurability(item2))) {
                         event.setCancelled(true);
                         event.getItem().remove();
                         event.getPlayer().playSound(event.getPlayer().getLocation(), Sound.ITEM_PICKUP, 0.1F, 1);
-                        toRepair.setDurability((short) (toRepair.getDurability() - (item1.getType().getMaxDurability() - item1.getDurability()) < 0 ? 0 : toRepair.getDurability() - (item1.getType().getMaxDurability() - item1.getDurability())));
+                        int result = item2.getDurability() - (item1.getType().getMaxDurability() - item1.getDurability());
+                        item2.setDurability((short) (result < 0 ? 0 : result));
+                        break;
                     }
                 }
             }
         }
+    }
+
+    public ItemStack toMaxDurability(ItemStack item) {
+        ItemStack item2 = new ItemStack(item);
+        item2.setDurability(item.getType().getMaxDurability());
+        return item2;
     }
 }


### PR DESCRIPTION
Now it literally checks that both items are exactly the same (without durability)
"toMaxDurability(1).equals(toMaxDurability(2))" Inspired by "1.toLowerCase() == 2.toLowerCase"
