### PR TITLE
Allow players to join obs even if the team changed name

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/command/JoinCommand.java
+++ b/src/main/java/in/twizmwaz/cardinal/command/JoinCommand.java
@@ -1,18 +1,11 @@
 package in.twizmwaz.cardinal.command;
 
-import com.google.common.base.Optional;
 import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
 import com.sk89q.minecraft.util.commands.CommandException;
-import in.twizmwaz.cardinal.GameHandler;
 import in.twizmwaz.cardinal.chat.ChatConstant;
-import in.twizmwaz.cardinal.chat.LocalizedChatMessage;
-import in.twizmwaz.cardinal.match.MatchState;
-import in.twizmwaz.cardinal.module.modules.team.TeamModule;
 import in.twizmwaz.cardinal.util.ChatUtil;
 import in.twizmwaz.cardinal.util.Teams;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -23,40 +16,22 @@ public class JoinCommand {
         if (!(sender instanceof Player)) {
             throw new CommandException(ChatConstant.ERROR_CONSOLE_NO_USE.getMessage(ChatUtil.getLocale(sender)));
         }
-        if (GameHandler.getGameHandler().getMatch().getState().equals(MatchState.ENDED) || GameHandler.getGameHandler().getMatch().getState().equals(MatchState.CYCLING)) {
-            throw new CommandException(ChatUtil.getWarningMessage(new LocalizedChatMessage(ChatConstant.ERROR_MATCH_OVER).getMessage(((Player) sender).getLocale())));
-        }
-        Optional<TeamModule> originalTeam = Teams.getTeamByPlayer((Player) sender);
-        if (cmd.argsLength() == 0 && originalTeam.isPresent() && !originalTeam.get().isObserver()) {
-            throw new CommandException(ChatUtil.getWarningMessage(ChatColor.RED + new LocalizedChatMessage(ChatConstant.ERROR_ALREADY_JOINED, Teams.getTeamByPlayer((Player) sender).get().getCompleteName() + ChatColor.RED).getMessage(((Player) sender).getLocale())));
-        }
-        Optional<TeamModule> destinationTeam = Optional.absent();
-        if (cmd.argsLength() > 0) {
-            for (TeamModule teamModule : GameHandler.getGameHandler().getMatch().getModules().getModules(TeamModule.class)) {
-                if (teamModule.getName().toLowerCase().startsWith(cmd.getJoinedStrings(0).toLowerCase())) {
-                    destinationTeam = Optional.of(teamModule);
-                    break;
-                }
-            }
-            if (!destinationTeam.isPresent()) {
-                throw new CommandException(ChatConstant.ERROR_NO_TEAM_MATCH.getMessage(ChatUtil.getLocale(sender)));
-            }
-            if (destinationTeam.get().contains(sender)) {
-                throw new CommandException(ChatUtil.getWarningMessage(ChatColor.RED + new LocalizedChatMessage(ChatConstant.ERROR_ALREADY_JOINED, destinationTeam.get().getCompleteName() + ChatColor.RED).getMessage(ChatUtil.getLocale(sender))));
-            }
-            destinationTeam.get().add((Player) sender, false);
-        } else {
-            destinationTeam = Teams.getTeamWithFewestPlayers(GameHandler.getGameHandler().getMatch());
-            if (destinationTeam.isPresent()) {
-                destinationTeam.get().add((Player) sender, false);
-            } else {
-                throw new CommandException(ChatConstant.ERROR_TEAMS_FULL.getMessage(ChatUtil.getLocale(sender)));
-            }
+        try {
+            Teams.setPlayerTeam((Player) sender, cmd.argsLength() > 0 ? cmd.getJoinedStrings(0) : "");
+        } catch (Exception e) {
+            throw new CommandException(e.getMessage());
         }
     }
 
     @Command(aliases = {"leave"}, desc = "Leave the game.")
-    public static void leave(final CommandContext cmd, CommandSender sender) {
-        Bukkit.getServer().dispatchCommand(sender, "join observers");
+    public static void leave(final CommandContext cmd, CommandSender sender) throws CommandException {
+        if (!(sender instanceof Player)) {
+            throw new CommandException(ChatConstant.ERROR_CONSOLE_NO_USE.getMessage(ChatUtil.getLocale(sender)));
+        }
+        try {
+            Teams.setPlayerTeam((Player) sender, Teams.getTeamById("observers").get().getName());
+        } catch (Exception e) {
+            throw new CommandException(e.getMessage());
+        }
     }
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/teamPicker/TeamPicker.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/teamPicker/TeamPicker.java
@@ -103,7 +103,11 @@ public class TeamPicker implements Module {
                                     event.setCancelled(true);
                                     player.closeInventory();
                                     player.playSound(player.getLocation(), Sound.BLOCK_DISPENSER_DISPENSE, 1, 2);
-                                    Bukkit.dispatchCommand(player, "join");
+                                    try {
+                                        Teams.setPlayerTeam(player, "");
+                                    } catch (Exception e) {
+                                        player.sendMessage(com.sk89q.minecraft.util.commands.ChatColor.RED + e.getMessage());
+                                    }
                                 }
                             }
                         }
@@ -114,7 +118,11 @@ public class TeamPicker implements Module {
                                     event.setCancelled(true);
                                     player.closeInventory();
                                     player.playSound(player.getLocation(), Sound.BLOCK_DISPENSER_DISPENSE, 1, 2);
-                                    Bukkit.dispatchCommand(player, "leave");
+                                    try {
+                                        Teams.setPlayerTeam(player, Teams.getTeamById("observers").get().getName());
+                                    } catch (Exception e) {
+                                        player.sendMessage(com.sk89q.minecraft.util.commands.ChatColor.RED + e.getMessage());
+                                    }
                                 }
                             }
                         }
@@ -125,7 +133,12 @@ public class TeamPicker implements Module {
                                     event.setCancelled(true);
                                     player.closeInventory();
                                     player.playSound(player.getLocation(), Sound.BLOCK_DISPENSER_DISPENSE, 1, 2);
-                                    Bukkit.dispatchCommand(player, "join " + ChatColor.stripColor(item.getItemMeta().getDisplayName()));
+                                    try {
+                                        Bukkit.getConsoleSender().sendMessage(player.getName() + " joined " + ChatColor.stripColor(item.getItemMeta().getDisplayName()));
+                                        Teams.setPlayerTeam(player, ChatColor.stripColor(item.getItemMeta().getDisplayName()));
+                                    } catch (Exception e) {
+                                        player.sendMessage(com.sk89q.minecraft.util.commands.ChatColor.RED + e.getMessage());
+                                    }
                                 } else {
                                     event.setCancelled(true);
                                     player.closeInventory();


### PR DESCRIPTION
/leave should always join obs.
I made it so that if you /join, and no team is found, and you typed part of the word observers, it will join you to obs, so, all : "/team o", "/team obs", /team "obser" should join you to obs even if the name was changed, unless there is a team that starts with that ("/team o" would join you to orange if there is a team named orange)