### PR TITLE
Fix null header names, display flairs for offline players, add map author flair, fixes #736

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/chat/ChatConstant.java
+++ b/src/main/java/in/twizmwaz/cardinal/chat/ChatConstant.java
@@ -202,6 +202,7 @@ public enum ChatConstant {
     GENERIC_MUTED_BY("generic.mutedBy"),
     GENERIC_UNMUTED("generic.unmuted"),
     GENERIC_UNMUTED_BY("generic.unmutedBy"),
+    GENERIC_CREATED_BY("generic.createdBy"),
 
     MISC_ENEMY("misc.enemy"),
     MISC_FATE("misc.fate"),

--- a/src/main/java/in/twizmwaz/cardinal/command/MapCommands.java
+++ b/src/main/java/in/twizmwaz/cardinal/command/MapCommands.java
@@ -35,21 +35,21 @@ public class MapCommands {
             sender.sendMessage(ChatColor.DARK_PURPLE + "" + ChatColor.BOLD + ChatConstant.UI_MAP_AUTHORS.getMessage(ChatUtil.getLocale(sender)) + ":");
             for (Contributor contributor : mapInfo.getAuthors()) {
                 if (contributor.getContribution() != null) {
-                    sender.sendMessage("* " + ChatColor.RED + contributor.getName() + ChatColor.RESET + " " + ChatColor.GREEN + "" + ChatColor.ITALIC + "(" + contributor.getContribution() + ")");
+                    sender.sendMessage("  " + contributor.getDisplayName() + ChatColor.GRAY + " - " + ChatColor.ITALIC + contributor.getContribution());
                 } else {
-                    sender.sendMessage("* " + ChatColor.RED + contributor.getName());
+                    sender.sendMessage("  " + contributor.getDisplayName());
                 }
             }
         } else {
-            sender.sendMessage(ChatColor.DARK_PURPLE + "" + ChatColor.BOLD + ChatConstant.UI_MAP_AUTHOR.getMessage(ChatUtil.getLocale(sender)) + ": " + ChatColor.RESET + ChatColor.GOLD + mapInfo.getAuthors().get(0).getName());
+            sender.sendMessage(ChatColor.DARK_PURPLE + "" + ChatColor.BOLD + ChatConstant.UI_MAP_AUTHOR.getMessage(ChatUtil.getLocale(sender)) + ": " + mapInfo.getAuthors().get(0).getDisplayName());
         }
         if (mapInfo.getContributors().size() > 0) {
             sender.sendMessage(ChatColor.DARK_PURPLE + "" + ChatColor.BOLD + ChatConstant.UI_MAP_CONTRIBUTORS.getMessage(ChatUtil.getLocale(sender)) + ":");
             for (Contributor contributor : mapInfo.getContributors()) {
                 if (contributor.getContribution() != null) {
-                    sender.sendMessage("* " + ChatColor.RED + contributor.getName() + ChatColor.RESET + ChatColor.GREEN + "" + ChatColor.ITALIC + " (" + contributor.getContribution() + ")");
+                    sender.sendMessage("  " + contributor.getDisplayName() + ChatColor.GRAY + " - " + ChatColor.ITALIC + contributor.getContribution());
                 } else {
-                    sender.sendMessage("* " + ChatColor.RED + contributor.getName());
+                    sender.sendMessage("  " + contributor.getDisplayName());
                 }
             }
         }

--- a/src/main/java/in/twizmwaz/cardinal/event/RankChangeEvent.java
+++ b/src/main/java/in/twizmwaz/cardinal/event/RankChangeEvent.java
@@ -11,11 +11,13 @@ public class RankChangeEvent extends Event {
     private final Player player;
     private Rank rank;
     private boolean adding;
+    private boolean online;
 
-    public RankChangeEvent(Player player, Rank rank, boolean adding) {
+    public RankChangeEvent(Player player, Rank rank, boolean adding, boolean online) {
         this.player = player;
         this.rank = rank;
         this.adding = adding;
+        this.online = online;
     }
 
     public static HandlerList getHandlerList() {
@@ -36,6 +38,10 @@ public class RankChangeEvent extends Event {
 
     public boolean isAdding() {
         return adding;
+    }
+
+    public boolean isOnline() {
+        return online;
     }
 
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/rank/RankModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/rank/RankModule.java
@@ -47,6 +47,7 @@ public class RankModule implements Module {
 
     @EventHandler
     public void onRankChange(RankChangeEvent event) {
+        if (!event.isOnline()) return;
         Player player = event.getPlayer();
 
         Bukkit.getPluginManager().callEvent(new PlayerNameUpdateEvent(player));

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/teamManager/TeamManagerModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/teamManager/TeamManagerModule.java
@@ -61,6 +61,30 @@ public class TeamManagerModule implements Module {
         }
         Bukkit.getConsoleSender().sendMessage(new UnlocalizedChatMessage(ChatColor.YELLOW + "{0}", new LocalizedChatMessage(ChatConstant.UI_PLAYER_JOIN, Teams.getTeamColorByPlayer(player) + player.getDisplayName() + ChatColor.YELLOW)).getMessage(Locale.getDefault().toString()));
 
+        sendMapMessage(player);
+    }
+
+    @EventHandler
+    public void onPlayerLeave(PlayerQuitEvent event) {
+        Player player = event.getPlayer();
+        event.setQuitMessage(null);
+        for (Player player1 : Bukkit.getOnlinePlayers()) {
+            if (!player1.equals(player)) {
+                player1.sendMessage(new UnlocalizedChatMessage(ChatColor.YELLOW + "{0}", new LocalizedChatMessage(ChatConstant.UI_PLAYER_LEAVE, Teams.getTeamColorByPlayer(player) + player.getDisplayName() + ChatColor.YELLOW)).getMessage(player1.getLocale()));
+            }
+        }
+        Bukkit.getConsoleSender().sendMessage(new UnlocalizedChatMessage(ChatColor.YELLOW + "{0}", new LocalizedChatMessage(ChatConstant.UI_PLAYER_LEAVE, Teams.getTeamColorByPlayer(player) + player.getDisplayName() + ChatColor.YELLOW)).getMessage(Locale.getDefault().toString()));
+        removePlayer(player);
+    }
+
+    @EventHandler
+    public void onCycleComplete(CycleCompleteEvent event) {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            sendMapMessage(player);
+        }
+    }
+
+    private void sendMapMessage(Player player) {
         player.sendMessage(ChatColor.STRIKETHROUGH + "--------" + ChatColor.AQUA + ChatColor.BOLD + " " + GameHandler.getGameHandler().getMatch().getLoadedMap().getName() + " " + ChatColor.RESET + ChatColor.STRIKETHROUGH + "--------");
         String line = "";
         if (GameHandler.getGameHandler().getMatch().getLoadedMap().getObjective().contains(" ")) {
@@ -82,15 +106,15 @@ public class TeamManagerModule implements Module {
             player.sendMessage(" " + line);
         }
         String locale = player.getLocale();
-        String result = ChatColor.DARK_GRAY + "Created by ";
+        String result = ChatColor.DARK_GRAY + new LocalizedChatMessage(ChatConstant.GENERIC_CREATED_BY).getMessage(locale) + " ";
         List<Contributor> authors = GameHandler.getGameHandler().getMatch().getLoadedMap().getAuthors();
         for (Contributor author : authors) {
             if (authors.indexOf(author) < authors.size() - 2) {
-                result = result + ChatColor.GRAY + author.getName() + ChatColor.DARK_GRAY + ", ";
+                result = result + author.getDisplayName() + ChatColor.DARK_GRAY + ", ";
             } else if (authors.indexOf(author) == authors.size() - 2) {
-                result = result + ChatColor.GRAY + author.getName() + ChatColor.DARK_GRAY + " " + new LocalizedChatMessage(ChatConstant.MISC_AND).getMessage(locale) + " ";
+                result = result + author.getDisplayName() + ChatColor.DARK_GRAY + " " + new LocalizedChatMessage(ChatConstant.MISC_AND).getMessage(locale) + " ";
             } else if (authors.indexOf(author) == authors.size() - 1) {
-                result = result + ChatColor.GRAY + author.getName();
+                result = result + author.getDisplayName();
             }
         }
         if (result.contains(" ")) {
@@ -111,75 +135,6 @@ public class TeamManagerModule implements Module {
             player.sendMessage(ChatColor.DARK_GRAY + " " + line);
         }
         player.sendMessage(ChatColor.STRIKETHROUGH + "---------------------------");
-    }
-
-    @EventHandler
-    public void onPlayerLeave(PlayerQuitEvent event) {
-        Player player = event.getPlayer();
-        event.setQuitMessage(null);
-        for (Player player1 : Bukkit.getOnlinePlayers()) {
-            if (!player1.equals(player)) {
-                player1.sendMessage(new UnlocalizedChatMessage(ChatColor.YELLOW + "{0}", new LocalizedChatMessage(ChatConstant.UI_PLAYER_LEAVE, Teams.getTeamColorByPlayer(player) + player.getDisplayName() + ChatColor.YELLOW)).getMessage(player1.getLocale()));
-            }
-        }
-        Bukkit.getConsoleSender().sendMessage(new UnlocalizedChatMessage(ChatColor.YELLOW + "{0}", new LocalizedChatMessage(ChatConstant.UI_PLAYER_LEAVE, Teams.getTeamColorByPlayer(player) + player.getDisplayName() + ChatColor.YELLOW)).getMessage(Locale.getDefault().toString()));
-        removePlayer(player);
-    }
-
-    @EventHandler
-    public void onCycleComplete(CycleCompleteEvent event) {
-        for (Player player : Bukkit.getOnlinePlayers()) {
-            player.sendMessage(ChatColor.STRIKETHROUGH + "--------" + ChatColor.AQUA + ChatColor.BOLD + " " + GameHandler.getGameHandler().getMatch().getLoadedMap().getName() + " " + ChatColor.RESET + ChatColor.STRIKETHROUGH + "--------");
-            String line = "";
-            if (GameHandler.getGameHandler().getMatch().getLoadedMap().getObjective().contains(" ")) {
-                for (String word : GameHandler.getGameHandler().getMatch().getLoadedMap().getObjective().split(" ")) {
-                    line += word + " ";
-                    if (line.trim().length() > 32) {
-                        line = ChatColor.BLUE + "" + ChatColor.ITALIC + line.trim();
-                        player.sendMessage(" " + line);
-                        line = "";
-                    }
-                }
-                if (!line.trim().equals("")) {
-                    line = ChatColor.BLUE + "" + ChatColor.ITALIC + line.trim();
-                    player.sendMessage(" " + line);
-                    line = "";
-                }
-            } else {
-                line = ChatColor.BLUE + "" + ChatColor.ITALIC + GameHandler.getGameHandler().getMatch().getLoadedMap().getObjective();
-                player.sendMessage(" " + line);
-            }
-            String locale = player.getLocale();
-            String result = ChatColor.DARK_GRAY + "Created by ";
-            List<Contributor> authors = GameHandler.getGameHandler().getMatch().getLoadedMap().getAuthors();
-            for (Contributor author : authors) {
-                if (authors.indexOf(author) < authors.size() - 2) {
-                    result = result + ChatColor.GRAY + author.getName() + ChatColor.DARK_GRAY + ", ";
-                } else if (authors.indexOf(author) == authors.size() - 2) {
-                    result = result + ChatColor.GRAY + author.getName() + ChatColor.DARK_GRAY + " " + new LocalizedChatMessage(ChatConstant.MISC_AND).getMessage(locale) + " ";
-                } else if (authors.indexOf(author) == authors.size() - 1) {
-                    result = result + ChatColor.GRAY + author.getName();
-                }
-            }
-            if (result.contains(" ")) {
-                for (String word : result.split(" ")) {
-                    line += word + " ";
-                    if (line.trim().length() > 32) {
-                        line = line.trim();
-                        player.sendMessage(ChatColor.DARK_GRAY + " " + line);
-                        line = "";
-                    }
-                }
-                if (!line.trim().equals("")) {
-                    line = line.trim();
-                    player.sendMessage(ChatColor.DARK_GRAY + " " + line);
-                }
-            } else {
-                line = result;
-                player.sendMessage(ChatColor.DARK_GRAY + " " + line);
-            }
-            player.sendMessage(ChatColor.STRIKETHROUGH + "---------------------------");
-        }
     }
 
     @EventHandler

--- a/src/main/java/in/twizmwaz/cardinal/rank/Rank.java
+++ b/src/main/java/in/twizmwaz/cardinal/rank/Rank.java
@@ -1,8 +1,10 @@
 package in.twizmwaz.cardinal.rank;
 
 import in.twizmwaz.cardinal.Cardinal;
+import in.twizmwaz.cardinal.GameHandler;
 import in.twizmwaz.cardinal.event.RankChangeEvent;
 import in.twizmwaz.cardinal.module.modules.permissions.PermissionModule;
+import in.twizmwaz.cardinal.util.Contributor;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -71,6 +73,16 @@ public class Rank {
         return null;
     }
 
+    public static boolean isMapAuthor(UUID uuid) {
+        if (!Bukkit.getOfflinePlayer(uuid).isOnline()) return false;
+        for (Contributor author : GameHandler.getGameHandler().getMatch().getLoadedMap().getAuthors()) {
+            if (author.getUniqueId() != null && author.getUniqueId().equals(uuid)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static String getPrefix(UUID uuid) {
         String prefix = "";
         String staffChar = "\u2756";
@@ -81,6 +93,16 @@ public class Rank {
             prefix += ChatColor.DARK_PURPLE + staffChar;
         }
         for (Rank rank : getRanks(uuid)) {
+            if (!rank.staffRank) continue;
+            if (rank.contains(uuid)) {
+                prefix += rank.getFlair();
+            }
+        }
+        if (isMapAuthor(uuid)) {
+            prefix += ChatColor.BLUE + "*";
+        }
+        for (Rank rank : getRanks(uuid)) {
+            if (rank.staffRank) continue;
             if (rank.contains(uuid)) {
                 prefix += rank.getFlair();
             }
@@ -109,9 +131,7 @@ public class Rank {
         List<String> players = config.contains("ranks." + name + ".players") ? config.getStringList("ranks." + name + ".players") : new ArrayList<String>();
         players.add(uuid.toString());
         config.set("ranks." + name + ".players", players);
-        if (Bukkit.getOfflinePlayer(uuid).isOnline()) {
-            Bukkit.getPluginManager().callEvent(new RankChangeEvent(Bukkit.getPlayer(uuid), this, true));
-        }
+        Bukkit.getPluginManager().callEvent(new RankChangeEvent(Bukkit.getPlayer(uuid), this, true, Bukkit.getOfflinePlayer(uuid).isOnline()));
     }
 
     public void remove(UUID uuid) {
@@ -119,9 +139,7 @@ public class Rank {
         List<String> players = config.contains("ranks." + name + ".players") ? config.getStringList("ranks." + name + ".players") : new ArrayList<String>();
         players.remove(uuid.toString());
         config.set("ranks." + name + ".players", players);
-        if (Bukkit.getOfflinePlayer(uuid).isOnline()) {
-            Bukkit.getPluginManager().callEvent(new RankChangeEvent(Bukkit.getPlayer(uuid), this, false));
-        }
+        Bukkit.getPluginManager().callEvent(new RankChangeEvent(Bukkit.getPlayer(uuid), this, false, Bukkit.getOfflinePlayer(uuid).isOnline()));
     }
 
     public boolean contains(UUID uuid) {

--- a/src/main/java/in/twizmwaz/cardinal/tabList/TabList.java
+++ b/src/main/java/in/twizmwaz/cardinal/tabList/TabList.java
@@ -167,6 +167,7 @@ public class TabList implements Listener {
 
     @EventHandler
     public void onRankChange(RankChangeEvent event) {
+        if (!event.isOnline()) return;
         updateAll(null);
     }
 
@@ -519,6 +520,14 @@ public class TabList implements Listener {
                 if (PermissionModule.isDeveloper(uuid1) && !PermissionModule.isDeveloper(uuid2)) return -1;
                 if (!PermissionModule.isDeveloper(uuid1) && PermissionModule.isDeveloper(uuid2)) return 1;
                 for (Rank rank : Rank.getRanks()) {
+                    if (!rank.isStaffRank()) continue;
+                    if (rank.contains(uuid1) && !rank.contains(uuid2)) return -1;
+                    if (!rank.contains(uuid1) && rank.contains(uuid2)) return 1;
+                }
+                if (Rank.isMapAuthor(uuid1) && !Rank.isMapAuthor(uuid2)) return -1;
+                if (!Rank.isMapAuthor(uuid1) && Rank.isMapAuthor(uuid2)) return 1;
+                for (Rank rank : Rank.getRanks()) {
+                    if (rank.isStaffRank()) continue;
                     if (rank.contains(uuid1) && !rank.contains(uuid2)) return -1;
                     if (!rank.contains(uuid1) && rank.contains(uuid2)) return 1;
                 }

--- a/src/main/java/in/twizmwaz/cardinal/util/Contributor.java
+++ b/src/main/java/in/twizmwaz/cardinal/util/Contributor.java
@@ -1,5 +1,9 @@
 package in.twizmwaz.cardinal.util;
 
+import in.twizmwaz.cardinal.rank.Rank;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+
 import java.util.UUID;
 
 public class Contributor {
@@ -26,13 +30,20 @@ public class Contributor {
         this(uniqueId, null);
     }
 
-
     public String getName() {
         return name;
     }
 
+    public String getDisplayName() {
+        if (uniqueId == null) return ChatColor.DARK_AQUA + name;
+        if (Bukkit.getOfflinePlayer(uniqueId).isOnline()) {
+            return Bukkit.getPlayer(uniqueId).getDisplayName();
+        } else {
+            return Rank.getPrefix(uniqueId) + ChatColor.DARK_AQUA + name;
+        }
+    }
+
     public void setName(String name) {
-        if (this.name != null) throw new UnsupportedOperationException("Contributor name is already set");
         this.name = name;
     }
 

--- a/src/main/java/in/twizmwaz/cardinal/util/Numbers.java
+++ b/src/main/java/in/twizmwaz/cardinal/util/Numbers.java
@@ -37,4 +37,5 @@ public class Numbers {
         if (number == Double.NEGATIVE_INFINITY) return "-\u221E";
         return (number + "").replaceAll("0", "\u2080").replaceAll("1", "\u2081").replaceAll("2", "\u2082").replaceAll("3", "\u2083").replaceAll("4", "\u2084").replaceAll("5", "\u2085").replaceAll("6", "\u2086").replaceAll("7", "\u2087").replaceAll("8", "\u2088").replaceAll("9", "\u2089");
     }
+
 }

--- a/src/main/java/in/twizmwaz/cardinal/util/Players.java
+++ b/src/main/java/in/twizmwaz/cardinal/util/Players.java
@@ -1,6 +1,7 @@
 package in.twizmwaz.cardinal.util;
 
 import in.twizmwaz.cardinal.module.modules.permissions.PermissionModule;
+import in.twizmwaz.cardinal.rank.Rank;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
@@ -39,14 +40,7 @@ public class Players {
     public static String getName(ServerOperator who, boolean flairs) {
         if (who instanceof OfflinePlayer) {
             OfflinePlayer player = (OfflinePlayer) who;
-            if (player.isOnline()) {
-                if (flairs) {
-                    return player.getPlayer().getDisplayName();
-                } else {
-                    return Teams.getTeamColorByPlayer(player) + player.getPlayer().getName();
-                }
-            }
-            return ChatColor.DARK_AQUA + player.getName();
+            return player.isOnline() ? (flairs ? player.getPlayer().getDisplayName() : Teams.getTeamColorByPlayer(player) + player.getPlayer().getName()) : Rank.getPrefix(player.getUniqueId()) + ChatColor.DARK_AQUA + player.getName();
         } else {
             return ChatColor.GOLD + "\u2756" + ChatColor.DARK_AQUA + "Console";
         }

--- a/src/main/resources/lang/en.xml
+++ b/src/main/resources/lang/en.xml
@@ -198,6 +198,7 @@
         <mutedBy>You were muted by {0}</mutedBy>
         <unmuted>You unmuted {0}</unmuted>
         <unmutedBy>You were unmuted by {0}</unmutedBy>
+        <createdBy>Created by</createdBy>
     </generic>
     <misc>
         <enemy>the enemy</enemy>


### PR DESCRIPTION
Also updates the /map format to:
![image](https://cloud.githubusercontent.com/assets/11789291/12700526/8a058edc-c7e7-11e5-8ca3-91cf6926ef22.png)
(Only talking about authors and contributors)
gamemode(needs 1.4 protocol), edition (N/A in a scrimm server) and XML(xml's are local, can't be viewed in a webpage) are not implemented in cardinal.