### PR TITLE
Fix empty result displayed on snowflakes command.

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/command/SnowflakesCommand.java
+++ b/src/main/java/in/twizmwaz/cardinal/command/SnowflakesCommand.java
@@ -22,10 +22,12 @@ public class SnowflakesCommand {
             Bukkit.dispatchCommand(sender, "snowflakes " + sender.getName());
         } else {
             OfflinePlayer player = Bukkit.getOfflinePlayer(cmd.getString(0));
+            String snowflakes = Cardinal.getCardinalDatabase().get(player, "snowflakes");
+            if (snowflakes.equals("")) snowflakes = "0";
             if (sender.equals(player)) {
-                sender.sendMessage(new UnlocalizedChatMessage(ChatColor.DARK_PURPLE + "{0} " + ChatColor.GOLD + "{1} {2}", ChatConstant.MISC_YOU_HAVE.asMessage(), new UnlocalizedChatMessage("{0}", Cardinal.getCardinalDatabase().get(player, "snowflakes")), Cardinal.getCardinalDatabase().get(player, "snowflakes").equals("1") ? ChatConstant.SNOWFLAKES_SNOWFLAKE.asMessage() : ChatConstant.SNOWFLAKES_SNOWFLAKES.asMessage()).getMessage(ChatUtil.getLocale(sender)));
+                sender.sendMessage(new UnlocalizedChatMessage(ChatColor.DARK_PURPLE + "{0} " + ChatColor.GOLD + "{1} {2}", ChatConstant.MISC_YOU_HAVE.asMessage(), new UnlocalizedChatMessage("{0}", snowflakes), snowflakes.equals("1") ? ChatConstant.SNOWFLAKES_SNOWFLAKE.asMessage() : ChatConstant.SNOWFLAKES_SNOWFLAKES.asMessage()).getMessage(ChatUtil.getLocale(sender)));
             } else {
-                sender.sendMessage(new UnlocalizedChatMessage(ChatColor.DARK_PURPLE + "{0} " + ChatColor.GOLD + "{1} {2}", new LocalizedChatMessage(ChatConstant.MISC_HAS, Players.getName(player) + ChatColor.DARK_PURPLE), new UnlocalizedChatMessage("{0}", Cardinal.getCardinalDatabase().get(player, "snowflakes")), Cardinal.getCardinalDatabase().get(player, "snowflakes").equals("1") ? ChatConstant.SNOWFLAKES_SNOWFLAKE.asMessage() : ChatConstant.SNOWFLAKES_SNOWFLAKES.asMessage()).getMessage(ChatUtil.getLocale(sender)));
+                sender.sendMessage(new UnlocalizedChatMessage(ChatColor.DARK_PURPLE + "{0} " + ChatColor.GOLD + "{1} {2}", new LocalizedChatMessage(ChatConstant.MISC_HAS, Players.getName(player) + ChatColor.DARK_PURPLE), new UnlocalizedChatMessage("{0}", snowflakes), snowflakes.equals("1") ? ChatConstant.SNOWFLAKES_SNOWFLAKE.asMessage() : ChatConstant.SNOWFLAKES_SNOWFLAKES.asMessage()).getMessage(ChatUtil.getLocale(sender)));
             }
         }
     }


### PR DESCRIPTION
When the `snowflakes` command is run and the player specified has no raindrops (stored as `""`) the message will return with a blank space (pulling from the empty db entry). This fix checks the snowflake amount previous to creating the ChatMessage and uses the value returned within the building of the message (translating `""` to `0`).

- Display a String of `0` if the return value is null/`""` (player has no
snowflakes).

![](http://i.imgur.com/uk23Pwb.png)

- Reduced to only check the db only once.