### PR TITLE
Add Plural support for teams.

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/chat/ChatConstant.java
+++ b/src/main/java/in/twizmwaz/cardinal/chat/ChatConstant.java
@@ -261,6 +261,7 @@ public enum ChatConstant {
     UI_MATCH_START_CANCELLED("userInterface.matchStartCancelled"),
     UI_MATCH_OVER("userInterface.matchOver"),
     UI_MATCH_WIN("userInterface.matchWin"),
+    UI_MATCH_WINS("userInterface.matchWins"),
     UI_MATCH_TEAM_WIN("userInterface.matchTeamWin"),
     UI_MATCH_TEAM_LOSE("userInterface.matchTeamLose"),
     UI_MATCH_MAX_SCORE_REACHED("userInterface.matchMaxScoreReached"),

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/match/MatchModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/match/MatchModule.java
@@ -33,10 +33,9 @@ public class MatchModule implements Module {
     @EventHandler
     public void onMatchEnd(MatchEndEvent event) {
         if (event.getTeam().isPresent()) {
-            ChatUtil.getGlobalChannel().sendLocalizedMessage(new UnlocalizedChatMessage("{0}", new LocalizedChatMessage(ChatConstant.UI_MATCH_WIN, event.getTeam().get().getCompleteName() + ChatColor.WHITE)));
+            ChatUtil.getGlobalChannel().sendLocalizedMessage(new UnlocalizedChatMessage("{0}", new LocalizedChatMessage(event.getTeam().get().isPlural() ? ChatConstant.UI_MATCH_WIN : ChatConstant.UI_MATCH_WINS, event.getTeam().get().getCompleteName() + ChatColor.WHITE)));
             for (Player player : Bukkit.getOnlinePlayers()) {
-                String title;
-                title = new LocalizedChatMessage(ChatConstant.UI_MATCH_WIN, event.getTeam().get().getCompleteName() + ChatColor.WHITE).getMessage(player.getLocale());
+                String title = new LocalizedChatMessage(event.getTeam().get().isPlural() ? ChatConstant.UI_MATCH_WIN : ChatConstant.UI_MATCH_WINS, event.getTeam().get().getCompleteName() + ChatColor.WHITE).getMessage(player.getLocale());
                 if (Teams.getTeamByPlayer(player).isPresent() && Teams.getTeamByPlayer(player).get() == event.getTeam().get()) {
                     player.sendMessage(new UnlocalizedChatMessage(ChatColor.GREEN + "{0}", new LocalizedChatMessage(ChatConstant.UI_MATCH_TEAM_WIN)).getMessage(player.getLocale()));
                     String subtitle = new LocalizedChatMessage(ChatConstant.UI_MATCH_TEAM_WIN).getMessage(player.getLocale());
@@ -50,16 +49,16 @@ public class MatchModule implements Module {
                 }
             }
         } else if (event.getPlayer().isPresent()){
-            ChatUtil.getGlobalChannel().sendLocalizedMessage(new UnlocalizedChatMessage("{0}", new LocalizedChatMessage(ChatConstant.UI_MATCH_WIN, ChatColor.YELLOW + (event.getPlayer().get()).getName() + ChatColor.WHITE)));
+            ChatUtil.getGlobalChannel().sendLocalizedMessage(new UnlocalizedChatMessage("{0}", new LocalizedChatMessage(event.getTeam().get().isPlural() ? ChatConstant.UI_MATCH_WIN : ChatConstant.UI_MATCH_WINS, ChatColor.YELLOW + (event.getPlayer().get()).getName() + ChatColor.WHITE)));
             for (Player player : Bukkit.getOnlinePlayers()) {
-                String title = new LocalizedChatMessage(ChatConstant.UI_MATCH_WIN, ChatColor.YELLOW + (event.getPlayer().get()).getName() + ChatColor.WHITE).getMessage(player.getLocale());
+                String title = new LocalizedChatMessage(event.getTeam().get().isPlural() ? ChatConstant.UI_MATCH_WIN : ChatConstant.UI_MATCH_WINS, ChatColor.YELLOW + (event.getPlayer().get()).getName() + ChatColor.WHITE).getMessage(player.getLocale());
                 player.showTitle(new TextComponent(title),new TextComponent(""), 0, 40, 30);
             }
         } else {
             ChatUtil.getGlobalChannel().sendLocalizedMessage(new UnlocalizedChatMessage("{0}", new LocalizedChatMessage(ChatConstant.UI_MATCH_OVER)));
             for (Player player : Bukkit.getOnlinePlayers()) {
                 String title = new LocalizedChatMessage(ChatConstant.UI_MATCH_OVER).getMessage(player.getLocale());
-                player.showTitle(new TextComponent(title),new TextComponent(""), 0, 20, 20);		
+                player.showTitle(new TextComponent(title),new TextComponent(""), 0, 20, 20);
             }
         }
     }

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/team/TeamModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/team/TeamModule.java
@@ -32,9 +32,10 @@ public class TeamModule<P extends Player> extends ArrayList<Player> implements M
     private int maxOverfill;
     private int respawnLimit;
     private ChatColor color;
+    private boolean plural;
     private boolean ready;
 
-    protected TeamModule(Match match, String name, String id, int min, int max, int maxOverfill, int respawnLimit, ChatColor color, boolean observer) {
+    protected TeamModule(Match match, String name, String id, int min, int max, int maxOverfill, int respawnLimit, ChatColor color, boolean plural, boolean observer) {
         this.match = match;
         this.name = name;
         this.id = id;
@@ -43,6 +44,7 @@ public class TeamModule<P extends Player> extends ArrayList<Player> implements M
         this.maxOverfill = maxOverfill;
         this.respawnLimit = respawnLimit;
         this.color = color;
+        this.plural = plural;
         this.observer = observer;
         this.ready = false;
     }
@@ -145,6 +147,10 @@ public class TeamModule<P extends Player> extends ArrayList<Player> implements M
 
     public void setColor(ChatColor color) {
         this.color = color;
+    }
+
+    public boolean isPlural() {
+        return plural;
     }
 
     public boolean isObserver() {

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/team/TeamModuleBuilder.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/team/TeamModuleBuilder.java
@@ -5,6 +5,7 @@ import in.twizmwaz.cardinal.module.BuilderData;
 import in.twizmwaz.cardinal.module.ModuleBuilder;
 import in.twizmwaz.cardinal.module.ModuleCollection;
 import in.twizmwaz.cardinal.module.ModuleLoadTime;
+import in.twizmwaz.cardinal.util.Numbers;
 import in.twizmwaz.cardinal.module.modules.blitz.Blitz;
 import in.twizmwaz.cardinal.util.Parser;
 import org.apache.logging.log4j.core.helpers.Integers;
@@ -45,10 +46,13 @@ public class TeamModuleBuilder implements ModuleBuilder {
             } catch (NullPointerException ex) {
                 respawnLimit = -1;
             }
+            boolean plural = false;
+            if (teamNode.getAttributeValue("plural") != null)
+                plural = Numbers.parseBoolean(teamNode.getAttributeValue("plural"));
             ChatColor color = Parser.parseChatColor(teamNode.getAttribute("color").getValue());
-            results.add(new TeamModule(match, name, id, min, max, maxOverfill, respawnLimit, color, false));
+            results.add(new TeamModule(match, name, id, min, max, maxOverfill, respawnLimit, color, plural, false));
         }
-        results.add(new TeamModule(match, "Observers", "observers", 0, Integer.MAX_VALUE, Integer.MAX_VALUE, -1, ChatColor.AQUA, true));
+        results.add(new TeamModule(match, "Observers", "observers", 0, Integer.MAX_VALUE, Integer.MAX_VALUE, -1, ChatColor.AQUA, true, true));
         return results;
     }
 }

--- a/src/main/resources/lang/en.xml
+++ b/src/main/resources/lang/en.xml
@@ -258,7 +258,8 @@
         <matchStartTitle>Go!</matchStartTitle>
         <matchStartCancelled>Match start cancelled</matchStartCancelled>
         <matchOver>Game over!</matchOver>
-        <matchWin>{0} wins!</matchWin>
+        <matchWin>{0} win!</matchWin>
+        <matchWins>{0} wins!</matchWins>
         <matchTeamWin>Your team won!</matchTeamWin>
         <matchTeamLose>Your team lost</matchTeamLose>
         <matchMaxScoreReached>Score limit of {0} reached</matchMaxScoreReached>

--- a/src/main/resources/lang/es.xml
+++ b/src/main/resources/lang/es.xml
@@ -176,6 +176,7 @@
         <matchStartCancelled>Se ha cancelado el inicio de la partida</matchStartCancelled>
         <matchOver>¡Partida terminada!</matchOver>
         <matchWin>¡{0} gana!</matchWin>
+        <matchWins>¡{0} gana!</matchWins>
         <matchTeamWin>¡Tu equipo ha ganado!</matchTeamWin>
         <matchTeamLose>Tu equipo ha perdido</matchTeamLose>
         <matchMaxScoreReached>Límite de puntuación de {0} alcanzado</matchMaxScoreReached>

--- a/src/main/resources/lang/fr.xml
+++ b/src/main/resources/lang/fr.xml
@@ -254,7 +254,7 @@
         <matchStartedTitle>Go!</matchStartedTitle>
         <matchStartCancelled>Début de match annulé</matchStartCancelled>
         <matchOver>Fin du jeu!</matchOver>
-        <matchWin>{0} a remporté la victoire !</matchWin>
+        <matchWins>{0} a remporté la victoire !</matchWins>
         <matchTeamWin>Votre équipe a gagné !</matchTeamWin>
         <matchTeamLose>Votre équipe a perdu</matchTeamLose>
         <matchMaxScoreReached>La limite du score de {0} a été atteinte</matchMaxScoreReached>

--- a/src/main/resources/lang/it.xml
+++ b/src/main/resources/lang/it.xml
@@ -160,7 +160,7 @@
         <matchStarted>La partita è cominciata!</matchStarted>
         <matchStartCancelled>L'inizio della partita è stato annullato</matchStartCancelled>
         <matchOver>Partita finita!</matchOver>
-        <matchWin>{0} ha vinto!</matchWin>
+        <matchWins>{0} ha vinto!</matchWins>
         <matchTeamWin>La tua squadra ha vinto!</matchTeamWin>
         <matchTeamLose>La tua squadra ha perso</matchTeamLose>
         <matchMaxScoreReached>Punteggio limite di {0} raggiunto</matchMaxScoreReached>

--- a/src/main/resources/lang/ko.xml
+++ b/src/main/resources/lang/ko.xml
@@ -165,7 +165,7 @@
         <matchStarted>경기가 시작되었습니다!</matchStarted>
         <matchStartCancelled>경기가 취소되었습니다.</matchStartCancelled>
         <matchOver>경기가 끝났습니다!</matchOver>
-        <matchWin>{0}가 승리했습니다!</matchWin>
+        <matchWins>{0}가 승리했습니다!</matchWins>
         <matchTeamWin>당신의 팀이 승리했습니다!</matchTeamWin>
         <matchTeamLose>당신의 팀이 패배하였습니다</matchTeamLose>
         <matchMaxScoreReached>{0}의 점수가 다 찼습니다.</matchMaxScoreReached>

--- a/src/main/resources/lang/sv.xml
+++ b/src/main/resources/lang/sv.xml
@@ -160,7 +160,7 @@
         <matchStarted>Matchen har börjat!</matchStarted>
         <matchStartCancelled>Matchstart avbruten</matchStartCancelled>
         <matchOver>Spelet är slut!</matchOver>
-        <matchWin>{0} vinner!</matchWin>
+        <matchWins>{0} vinner!</matchWins>
         <matchTeamWin>Ditt lag vann!</matchTeamWin>
         <matchTeamLose>Ditt lag förlorade</matchTeamLose>
         <matchMaxScoreReached>Poänggränsen {0} nådd</matchMaxScoreReached>

--- a/src/main/resources/lang/zh.xml
+++ b/src/main/resources/lang/zh.xml
@@ -157,7 +157,7 @@
         <matchStarted>比赛开始！</matchStarted>
         <matchStartCancelled>即将来临的比赛被取消了</matchStartCancelled>
         <matchOver>比赛完了</matchOver>
-        <matchWin>{0} 赢！</matchWin>
+        <matchWins>{0} 赢！</matchWins>
         <matchTeamWin>你的队赢了！</matchTeamWin>
         <matchTeamLose>你的队输了。</matchTeamLose>
         <matchMaxScoreReached>到了分数的限制， {0} 了。</matchMaxScoreReached>


### PR DESCRIPTION
Add support for `plural="true"` in team element. 
This is then displayed once a game has ended in both chat and titles.

![](http://i.imgur.com/BDaw5iZ.png)

- Change `matchWin` to `matchWins` in lang files.
- Add plural version named `matchWin` to EN and ES.
- Edit ChatConstants and TeamBuilder/Module.
- Add plural functionality to MatchModule.