### PR TITLE
Fix single author contributions, fixes #969.

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/command/MapCommands.java
+++ b/src/main/java/in/twizmwaz/cardinal/command/MapCommands.java
@@ -41,7 +41,11 @@ public class MapCommands {
                 }
             }
         } else {
-            sender.sendMessage(ChatColor.DARK_PURPLE + "" + ChatColor.BOLD + ChatConstant.UI_MAP_AUTHOR.getMessage(ChatUtil.getLocale(sender)) + ": " + mapInfo.getAuthors().get(0).getDisplayName());
+            if (mapInfo.getAuthors().get(0).getContribution() != null) {
+                sender.sendMessage(ChatColor.DARK_PURPLE + "" + ChatColor.BOLD + ChatConstant.UI_MAP_AUTHOR.getMessage(ChatUtil.getLocale(sender)) + ": " + mapInfo.getAuthors().get(0).getDisplayName() + ChatColor.GRAY + " - " + ChatColor.ITALIC + mapInfo.getAuthors().get(0).getContribution());
+            } else {
+                sender.sendMessage(ChatColor.DARK_PURPLE + "" + ChatColor.BOLD + ChatConstant.UI_MAP_AUTHOR.getMessage(ChatUtil.getLocale(sender)) + ": " + mapInfo.getAuthors().get(0).getDisplayName());
+            }
         }
         if (mapInfo.getContributors().size() > 0) {
             sender.sendMessage(ChatColor.DARK_PURPLE + "" + ChatColor.BOLD + ChatConstant.UI_MAP_CONTRIBUTORS.getMessage(ChatUtil.getLocale(sender)) + ":");


### PR DESCRIPTION
- When a map has a single author and has a contributions message it now show in `/map`.

As "described" in #969.

![](http://i.imgur.com/AzChzrT.png)
