### PR TITLE
Add exploding TNT Dispensers.

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/tnt/Tnt.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/tnt/Tnt.java
@@ -1,10 +1,13 @@
 package in.twizmwaz.cardinal.module.modules.tnt;
 
 import in.twizmwaz.cardinal.GameHandler;
+import in.twizmwaz.cardinal.match.MatchState;
 import in.twizmwaz.cardinal.module.Module;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.Dispenser;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.event.EventHandler;
@@ -13,10 +16,15 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.ExplosionPrimeEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
+import java.util.UUID;
 
 public class Tnt implements Module {
 
@@ -25,13 +33,17 @@ public class Tnt implements Module {
     private final double yield;
     private final double power;
     private final int fuse;
+    private final int limit;
+    private final double multiplier;
 
-    protected Tnt(final boolean instantIgnite, final boolean blockDamage, final double yield, final double power, final int fuse) {
+    protected Tnt(final boolean instantIgnite, final boolean blockDamage, final double yield, final double power, final int fuse, final int limit, final double multiplier) {
         this.instantIgnite = instantIgnite;
         this.blockDamage = blockDamage;
         this.yield = yield;
         this.power = power;
         this.fuse = fuse;
+        this.limit = limit;
+        this.multiplier = multiplier;
     }
 
     @Override
@@ -69,8 +81,38 @@ public class Tnt implements Module {
             } else if (yield != 0.3){
                 event.setYield((float)yield);
             }
+            TNTPrimed tntPrimed = (TNTPrimed) event.getEntity();
+            UUID player = tntPrimed.hasMetadata("source") ? ((UUID) tntPrimed.getMetadata("source", GameHandler.getGameHandler().getPlugin()).value()) : null;
+            for (Block block : event.blockList()) {
+                if (block.getState() instanceof Dispenser) {
+                    Inventory inventory = ((Dispenser) block.getState()).getInventory();
+                    Location location = block.getLocation();
+                    double tntCount = 0;
+                    for (ItemStack itemstack : inventory.getContents()) {
+                        if (itemstack != null && itemstack.getType() == Material.TNT) tntCount += itemstack.getAmount() * multiplier;
+                        if (tntCount > limit) {
+                            tntCount = limit;
+                            break;
+                        }
+                    }
+                    inventory.remove(Material.TNT);
+                    if (tntCount > 0) {
+                        if (GameHandler.getGameHandler().getMatch().getState().equals(MatchState.PLAYING)) {
+                            Random random = new Random();
+                            for (double i = tntCount; i > 0; i--) {
+                                TNTPrimed tnt = event.getWorld().spawn(location, TNTPrimed.class);
+                                Vector velocity = new Vector((1.5 * random.nextDouble()) - 0.75, (1.5 * random.nextDouble()) - 0.75, (1.5 * random.nextDouble()) - 0.75);
+                                tnt.setVelocity(velocity);
+                                tnt.setFuseTicks(random.nextInt(10) + 10);
+                                if (player != null) {
+                                    tnt.setMetadata("source", new FixedMetadataValue(GameHandler.getGameHandler().getPlugin(), player));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
-
 
 }

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/tnt/TntBuilder.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/tnt/TntBuilder.java
@@ -12,29 +12,39 @@ public class TntBuilder implements ModuleBuilder {
     @Override
     public ModuleCollection<Tnt> load(Match match) {
         ModuleCollection<Tnt> results = new ModuleCollection<>();
-        for (Element element : match.getDocument().getRootElement().getChildren("tnt")) {
-            boolean instantIgnite = false;
-            if (element.getChild("instantignite") != null) {
-                instantIgnite = Numbers.parseBoolean(element.getChildText("instantignite"));
+        if (match.getDocument().getRootElement().getChild("tnt") != null) {
+            for (Element element : match.getDocument().getRootElement().getChildren("tnt")) {
+                boolean instantIgnite = false;
+                if (element.getChild("instantignite") != null) {
+                    instantIgnite = Numbers.parseBoolean(element.getChildText("instantignite"));
+                }
+                boolean blockDamage = true;
+                if (element.getChild("blockdamage") != null) {
+                    blockDamage = Numbers.parseBoolean(element.getChildText("blockdamage"));
+                }
+                double yield = 0.3;
+                if (element.getChild("yield") != null) {
+                    yield = Double.parseDouble(element.getChildText("yield"));
+                }
+                double power = 4.0;
+                if (element.getChild("power") != null) {
+                    power = Double.parseDouble(element.getChildText("power"));
+                }
+                int fuse = 4;
+                if (element.getChild("fuse") != null) {
+                    fuse = Strings.timeStringToSeconds(element.getChildText("fuse"));
+                }
+                int limit = 16;
+                if (element.getChild("dispenser-tnt-limit") != null) {
+                    limit = Strings.timeStringToSeconds(element.getChildText("dispenser-tnt-limit"));
+                }
+                double multiplier = 0.25;
+                if (element.getChild("dispenser-tnt-multiplier") != null) {
+                    multiplier = Double.parseDouble(element.getChildText("dispenser-tnt-multiplier"));
+                }
+                results.add(new Tnt(instantIgnite, blockDamage, yield, power, fuse, limit, multiplier));
             }
-            boolean blockDamage = true;
-            if (element.getChild("blockdamage") != null) {
-                blockDamage = Numbers.parseBoolean(element.getChildText("blockdamage"));
-            }
-            double yield = 0.3;
-            if (element.getChild("yield") != null) {
-                yield = Double.parseDouble(element.getChildText("yield"));
-            }
-            double power = 4.0;
-            if (element.getChild("power") != null) {
-                power = Double.parseDouble(element.getChildText("power"));
-            }
-            int fuse = 4;
-            if (element.getChild("fuse") != null) {
-                fuse = Strings.timeStringToSeconds(element.getChildText("fuse"));
-            }
-            results.add(new Tnt(instantIgnite, blockDamage, yield, power, fuse));
-        }
+        } else results.add(new Tnt(false, true, 0.3, 4.0, 4, 16, 0.25));
         return results;
     }
 


### PR DESCRIPTION
When a dispensers is blown up the amount of TNT inside will be counted and `x` amount of TNT will be spawned determined by both the `multiplier` and `limit`.

The owner of the spawned TNT is set to the owner of the TNT which caused the explosion.
Due to my last commit if the TNT dispensed causes it to blow up the owner will be the dispenser owner.

Fixes #737, example video of explosions [here](https://youtu.be/d8xKvfj3_Gg).
I had originally set this up as a new module however it uses the same XML elements as TNT so it was merged.
