### PR TITLE
Prevent Title respawn Armor Stand showing health in GUI

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/guiKeep/GuiKeepModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/guiKeep/GuiKeepModule.java
@@ -1,10 +1,8 @@
 package in.twizmwaz.cardinal.module.modules.guiKeep;
 
-import com.google.common.base.Optional;
 import in.twizmwaz.cardinal.GameHandler;
 import in.twizmwaz.cardinal.module.Module;
-import in.twizmwaz.cardinal.module.modules.team.TeamModule;
-import in.twizmwaz.cardinal.util.Teams;
+import in.twizmwaz.cardinal.module.modules.observers.ObserverModule;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -20,8 +18,7 @@ public class GuiKeepModule implements Module {
 
     @EventHandler
     public void onPlayerInteract(PlayerInteractEvent event) {
-        Optional<TeamModule> team = Teams.getTeamByPlayer(event.getPlayer());
-        if (GameHandler.getGameHandler().getMatch().isRunning() && (!team.isPresent() || !team.orNull().isObserver())) {
+        if (GameHandler.getGameHandler().getMatch().isRunning() && !ObserverModule.testObserverOrDead(event.getPlayer())) {
             if (event.getAction().equals(Action.RIGHT_CLICK_BLOCK)) {
                 if (event.getClickedBlock() != null) {
                     if (event.getClickedBlock().getType().equals(Material.WORKBENCH)) {

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/kit/KitNode.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/kit/KitNode.java
@@ -83,6 +83,7 @@ public class KitNode implements KitRemovable {
                 }
             }
         }
+        player.updateInventory();
     }
 
     @Override
@@ -93,6 +94,7 @@ public class KitNode implements KitRemovable {
         for (KitNode kit : parentKits) {
             kit.remove(player);
         }
+        player.updateInventory();
     }
 
     public String getName() {


### PR DESCRIPTION
It will make it so that the hearts of the entity you are ridding don't show up
It also fixes you being able to open crafting tables while you are dead
It fixes that when you switch teams, inventory doesn't update properly sometimes

Opinions?