### PR TITLE
Add polls

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/Cardinal.java
+++ b/src/main/java/in/twizmwaz/cardinal/Cardinal.java
@@ -23,6 +23,7 @@ import in.twizmwaz.cardinal.command.ListCommand;
 import in.twizmwaz.cardinal.command.MapCommands;
 import in.twizmwaz.cardinal.command.MatchCommand;
 import in.twizmwaz.cardinal.command.ModesCommand;
+import in.twizmwaz.cardinal.command.PollCommands;
 import in.twizmwaz.cardinal.command.PrivateMessageCommands;
 import in.twizmwaz.cardinal.command.ProximityCommand;
 import in.twizmwaz.cardinal.command.PunishmentCommands;
@@ -156,6 +157,7 @@ public class Cardinal extends JavaPlugin {
         cmdRegister.register(TeleportCommands.class);
         cmdRegister.register(TimeLimitCommand.class);
         cmdRegister.register(WhitelistCommands.WhitelistParentCommand.class);
+        cmdRegister.register(PollCommands.class);
 
 
     }

--- a/src/main/java/in/twizmwaz/cardinal/chat/ChatConstant.java
+++ b/src/main/java/in/twizmwaz/cardinal/chat/ChatConstant.java
@@ -110,6 +110,11 @@ public enum ChatConstant {
     ERROR_PROXIMITY_OBS_ONLY("error.proximityObsOnly"),
     ERROR_PROXIMITY_NO_SCORING("error.proximityNoScoring"),
     ERROR_INVENTORY_NOT_VIEWABLE("error.inventoryNotViewable"),
+    ERROR_POLL_NEED_ID("error.pollNeedId"),
+    ERROR_POLL_NO_POLLS("error.pollNoPolls"),
+    ERROR_POLL_NO_SUCH_POLL("error.pollNoSuchPoll"),
+    ERROR_POLL_ALREADY_VOTED("error.pollAlreadyVoted"),
+    ERROR_POLL_USAGE("error.pollUsage"),
 
     GENERIC_MAP_SET("generic.mapSet"),
     GENERIC_MARKED_FOR_RELOADING("generic.markedForReloading"),
@@ -206,6 +211,11 @@ public enum ChatConstant {
     GENERIC_UNMUTED("generic.unmuted"),
     GENERIC_UNMUTED_BY("generic.unmutedBy"),
     GENERIC_CREATED_BY("generic.createdBy"),
+    GENERIC_POLL_VOTED("generic.pollVoted"),
+    GENERIC_POLL_VOTED_AGAINST("generic.pollVotedAgainst"),
+    GENERIC_POLL_SUCCEEDED("generic.pollSucceeded"),
+    GENERIC_POLL_FAILED("generic.pollFailed"),
+    GENERIC_POLL_VETOED("generic.pollVetoed"),
 
     MISC_ENEMY("misc.enemy"),
     MISC_FATE("misc.fate"),
@@ -321,6 +331,7 @@ public enum ChatConstant {
     UI_COMPASS("userInterface.compass"),
     UI_WAITING_PLAYER("userInterface.waitingPlayer"),
     UI_WAITING_PLAYERS("userInterface.waitingPlayers"),
+    UI_POLL_BOSSBAR("userInterface.pollBossbar"),
 
     UI_DEATH_RESPAWN_UNCONFIRMED("userInterface.deathRespawnUnconfirmed"),
     UI_DEATH_RESPAWN_UNCONFIRMED_TIME("userInterface.deathRespawnUnconfirmedTime"),

--- a/src/main/java/in/twizmwaz/cardinal/command/PollCommands.java
+++ b/src/main/java/in/twizmwaz/cardinal/command/PollCommands.java
@@ -1,0 +1,72 @@
+package in.twizmwaz.cardinal.command;
+
+import com.sk89q.minecraft.util.commands.Command;
+import com.sk89q.minecraft.util.commands.CommandContext;
+import com.sk89q.minecraft.util.commands.CommandException;
+import com.sk89q.minecraft.util.commands.CommandPermissions;
+import in.twizmwaz.cardinal.chat.ChatConstant;
+import in.twizmwaz.cardinal.chat.LocalizedChatMessage;
+import in.twizmwaz.cardinal.util.ChatUtil;
+import in.twizmwaz.cardinal.util.Strings;
+import in.twizmwaz.cardinal.util.polls.Polls;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class PollCommands {
+
+    @Command(aliases = {"poll"}, flags = "at:", desc = "Creates a poll to run a command", usage = "<command>", min = 1, anyFlags = true)
+    @CommandPermissions("cardinal.poll.add")
+    public static void poll(final CommandContext cmd, CommandSender sender) throws CommandException {
+        Polls.addPoll(sender, cmd.getJoinedStrings(0), Strings.timeStringToSeconds(cmd.getFlag('t', "60")), cmd.hasFlag('a'));
+    }
+
+    @Command(aliases = {"vote"}, desc = "Votes in a poll", usage = "[id] <yes|no>", min = 1, max = 2)
+    public static void vote(final CommandContext cmd, CommandSender sender) throws CommandException {
+        Integer pollId = findPoll(cmd.argsLength() == 1 ? null : cmd.getInteger(0), sender);
+        if (!Polls.isPoll(pollId)) {
+            throw new CommandException(new LocalizedChatMessage(ChatConstant.ERROR_POLL_NO_SUCH_POLL, "" + pollId).getMessage(ChatUtil.getLocale(sender)));
+        }
+        if (!sender.hasPermission("cardinal.poll.vote") && !Polls.isAny(pollId)) {
+            throw new CommandException(ChatConstant.ERROR_NO_PERMISSION.getMessage(ChatUtil.getLocale(sender)));
+        }
+        String voteArg = cmd.getString(cmd.argsLength() -1).toLowerCase();
+        if ("yes".startsWith(voteArg) || "no".startsWith(voteArg)) {
+            boolean vote = "yes".startsWith(voteArg);
+            boolean success = Polls.vote(pollId, (Player) sender, vote);
+            if (success) {
+                sender.sendMessage((vote ? ChatColor.GREEN : ChatColor.RED) + new LocalizedChatMessage(vote ? ChatConstant.GENERIC_POLL_VOTED : ChatConstant.GENERIC_POLL_VOTED_AGAINST, ChatColor.GOLD + "" + pollId + (vote ? ChatColor.GREEN : ChatColor.RED)).getMessage(ChatUtil.getLocale(sender)));
+            } else {
+                throw new CommandException(ChatConstant.ERROR_POLL_ALREADY_VOTED.getMessage(ChatUtil.getLocale(sender)));
+            }
+        } else {
+            throw new CommandException(ChatConstant.ERROR_INVALID_ARGUMENTS.getMessage(ChatUtil.getLocale(sender)) + " yes | no");
+        }
+    }
+
+    @Command(aliases = {"veto"}, desc = "Vetoes a poll", min = 0, max = 1)
+    @CommandPermissions("cardinal.poll.veto")
+    public static void veto(final CommandContext cmd, CommandSender sender) throws CommandException {
+        int pollId = findPoll(cmd.argsLength() == 0 ? null : cmd.getInteger(0), sender);
+        Polls.stopPoll(pollId, sender);
+    }
+
+    private static int findPoll(Integer id, CommandSender sender) throws CommandException {
+        if (id != null) {
+            if (Polls.isPoll(id)) {
+                return id;
+            } else {
+                throw new CommandException(new LocalizedChatMessage(ChatConstant.ERROR_POLL_NO_SUCH_POLL, "" + id).getMessage(ChatUtil.getLocale(sender)));
+            }
+        } else {
+            id = Polls.getPoll();
+            if (id == -1) {
+                throw new CommandException(ChatConstant.ERROR_POLL_NEED_ID.getMessage(ChatUtil.getLocale(sender)));
+            } else if (id == 0) {
+                throw new CommandException(ChatConstant.ERROR_POLL_NO_POLLS.getMessage(ChatUtil.getLocale(sender)));
+            }
+            return id;
+        }
+    }
+
+}

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/permissions/PermissionModule.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/permissions/PermissionModule.java
@@ -73,14 +73,6 @@ public class PermissionModule implements Module {
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
-    public void onPlayerKick(PlayerKickEvent event) {
-        if (attachmentMap.containsKey(event.getPlayer().getUniqueId())) {
-            event.getPlayer().removeAttachment(attachmentMap.get(event.getPlayer().getUniqueId()));
-            attachmentMap.remove(event.getPlayer().getUniqueId());
-        }
-    }
-
     @EventHandler
     public void onPlayerChangeTeam(PlayerChangeTeamEvent event) {
         if (Cardinal.getInstance().getConfig().getBoolean("worldEditPermissions")) {

--- a/src/main/java/in/twizmwaz/cardinal/util/polls/Poll.java
+++ b/src/main/java/in/twizmwaz/cardinal/util/polls/Poll.java
@@ -1,0 +1,114 @@
+package in.twizmwaz.cardinal.util.polls;
+
+import in.twizmwaz.cardinal.Cardinal;
+import in.twizmwaz.cardinal.chat.ChatConstant;
+import in.twizmwaz.cardinal.chat.LocalizedChatMessage;
+import in.twizmwaz.cardinal.chat.UnlocalizedChatMessage;
+import in.twizmwaz.cardinal.util.ChatUtil;
+import in.twizmwaz.cardinal.util.Players;
+import in.twizmwaz.cardinal.util.bossBar.BossBars;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
+import org.bukkit.command.CommandSender;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+class Poll {
+
+    private int id;
+    private CommandSender sender;
+    private String command;
+    private boolean any;
+    private int time;
+    private final int originalTime;
+    private int taskId;
+    private String bossBar;
+    private Set<UUID> votedYes = new HashSet<>();
+    private Set<UUID> votedNo = new HashSet<>();
+
+    protected Poll(int id, CommandSender sender, String command, int time, boolean any) {
+        this.id = id;
+        this.sender = sender;
+        this.command = command;
+        this.any = any;
+        this.time = time * 20;
+        this.originalTime = this.time;
+        this.bossBar = BossBars.addBroadcastedBossBar(new UnlocalizedChatMessage(""), BarColor.YELLOW, BarStyle.SOLID, true);
+        taskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(Cardinal.getInstance(), new Runnable() {
+            @Override
+            public void run() {
+                Poll.this.update();
+            }
+        }, 0L, 1L);
+    }
+
+    protected boolean vote(UUID uuid, boolean vote) {
+        if ((vote && votedYes.contains(uuid)) || (!vote && votedNo.contains(uuid))) {
+            return false;
+        }
+        if (vote) {
+            if (votedNo.contains(uuid)) votedNo.remove(uuid);
+            votedYes.add(uuid);
+        } else {
+            if (votedYes.contains(uuid)) votedYes.remove(uuid);
+            votedNo.add(uuid);
+        }
+        return true;
+    }
+
+    protected boolean any() {
+        return any;
+    }
+
+    protected void updateTitle () {
+        int intTime = time % 20 == 0 ? (time / 20) : (time / 20) + 1;
+        BossBars.setTitle(bossBar, new LocalizedChatMessage(ChatConstant.UI_POLL_BOSSBAR,
+                new UnlocalizedChatMessage((Polls.multiple() ? ChatColor.RED + "" + id + ": " : "") + ChatColor.YELLOW),
+                new UnlocalizedChatMessage(command() + ChatColor.YELLOW),
+                intTime == 1 ? new LocalizedChatMessage(ChatConstant.UI_SECOND, ChatColor.DARK_RED + "1" + ChatColor.YELLOW) :
+                        new LocalizedChatMessage(ChatConstant.UI_SECONDS, ChatColor.DARK_RED + "" + intTime + ChatColor.YELLOW),
+                new UnlocalizedChatMessage(result())));
+    }
+
+    private void update() {
+        if (time == 0) {
+            end();
+            return;
+        }
+        if (time % 20 == 0) updateTitle();
+        BossBars.setProgress(bossBar, (double)time / originalTime);
+        time--;
+    }
+
+    private String command() {
+        return ChatColor.RED + "\"" + ChatColor.GOLD + command + ChatColor.RED + "\"";
+    }
+
+    private String result() {
+        return ChatColor.YELLOW + "[" + ChatColor.DARK_GREEN + votedYes.size() + " " + ChatColor.DARK_RED + votedNo.size() + ChatColor.YELLOW + "]";
+    }
+
+    private void end() {
+        boolean succeed = votedYes.size() > votedNo.size();
+        ChatColor color = succeed ? ChatColor.DARK_GREEN : ChatColor.DARK_RED;
+        ChatUtil.getGlobalChannel().sendLocalizedMessage(new UnlocalizedChatMessage(color + "{0}", new LocalizedChatMessage(succeed ? ChatConstant.GENERIC_POLL_SUCCEEDED : ChatConstant.GENERIC_POLL_FAILED, command() + color, result())));
+        stop(null);
+        if (succeed) Bukkit.dispatchCommand(sender, command);
+    }
+
+    protected void stop(CommandSender sender) {
+        if (sender != null) ChatUtil.getGlobalChannel().sendLocalizedMessage(new UnlocalizedChatMessage(ChatColor.RED + "{0}", new LocalizedChatMessage(ChatConstant.GENERIC_POLL_VETOED, command() + ChatColor.RED, Players.getName(sender))));
+        Bukkit.getScheduler().cancelTask(taskId);
+        BossBars.removeBroadcastedBossBar(bossBar);
+        Polls.removePoll(id);
+        this.votedYes = null;
+        this.votedNo = null;
+        this.bossBar = null;
+    }
+
+}
+

--- a/src/main/java/in/twizmwaz/cardinal/util/polls/Polls.java
+++ b/src/main/java/in/twizmwaz/cardinal/util/polls/Polls.java
@@ -1,0 +1,55 @@
+package in.twizmwaz.cardinal.util.polls;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Polls {
+
+    private static Map<Integer, Poll> polls = new HashMap<>();
+
+    public static boolean multiple() {
+        return polls.size() > 1;
+    }
+
+    public static int getPoll() {
+        return polls.size() == 0 ? 0 : polls.size() == 1 ? polls.keySet().iterator().next() : -1;
+    }
+
+    public static boolean isPoll(int id) {
+        return polls.containsKey(id);
+    }
+
+    public static boolean isAny(int id) {
+        return polls.get(id).any();
+    }
+
+    public static boolean vote(int id, Player player, boolean vote) {
+        boolean result = polls.get(id).vote(player.getUniqueId(), vote);
+        polls.get(id).updateTitle();
+        return result;
+    }
+
+    public static void addPoll(CommandSender sender, String command, int time, boolean any) {
+        int id = polls.size() == 0 ? 1 : Collections.max(polls.keySet()) + 1;
+        polls.put(id, new Poll(id, sender, command, time, any));
+        updatePolls();
+    }
+
+    public static void stopPoll(int id, CommandSender sender) {
+        polls.get(id).stop(sender);
+        updatePolls();
+    }
+
+    protected static void removePoll(int id) {
+        polls.remove(id);
+    }
+
+    private static void updatePolls() {
+        for (Poll poll : polls.values()) poll.updateTitle();
+    }
+
+}

--- a/src/main/resources/lang/en.xml
+++ b/src/main/resources/lang/en.xml
@@ -104,6 +104,10 @@
         <proximityObsOnly>The /proximity command is only available to observers.</proximityObsOnly>
         <proximityNoScoring>There are no objectives that track proximity.</proximityNoScoring>
         <inventoryNotViewable>Player's inventory is not currently viewable</inventoryNotViewable>
+        <pollNeedId>Multiple polls are running, specify a poll id.</pollNeedId>
+        <pollNoPolls>No polls are running.</pollNoPolls>
+        <pollNoSuchPoll>Poll {0} is not running</pollNoSuchPoll>
+        <pollAlreadyVoted>You already voted.</pollAlreadyVoted>
     </error>
     <generic>
         <mapSet>Next map set to {0}</mapSet>
@@ -202,6 +206,11 @@
         <unmuted>You unmuted {0}</unmuted>
         <unmutedBy>You were unmuted by {0}</unmutedBy>
         <createdBy>Created by</createdBy>
+        <pollVoted>You voted for Poll {0}</pollVoted>
+        <pollVotedAgainst>You voted against Poll {0}</pollVotedAgainst>
+        <pollSucceeded>Poll to {0} succeeded {1}</pollSucceeded>
+        <pollFailed>Poll to {0} failed {1}</pollFailed>
+        <pollVetoed>Poll to {0} was vetoed by {1}</pollVetoed>
     </generic>
     <misc>
         <enemy>the enemy</enemy>
@@ -325,6 +334,7 @@
         <deathRespawnConfirmedTime>Respawning in {0}s</deathRespawnConfirmedTime>
         <deathRespawnConfirmedWaiting>You will respawn as soon as possible...</deathRespawnConfirmedWaiting>
         <deathRespawnConfirmedWaitingFlagDropped>You will respawn when the flag is dropped...</deathRespawnConfirmedWaitingFlagDropped>
+        <pollBossbar>{0}Poll to {1} will end in {2} {3}</pollBossbar>
     </userInterface>
     <deathMsg>
         <explosionSelf>{0} 'sploded</explosionSelf>


### PR DESCRIPTION
By default, only players with `cardinal.poll.vote` permission can vote, and the time is 60 seconds


To start a poll (that will run the `/say hi` command when it ends):
- `/poll say hi`
- `/poll -a say hi` anyone can vote
- `/poll -t 10 say hi` the poll will end in 10 seconds
- `/poll -at 10 say hi` anyone can vote, and the poll ends in 10 seconds
- `/poll -t 1m30s say hi` the poll ends in 1 minute and 30 seconds



To vote:
- `/vote yes` votes in the current poll
- `/vote 1 yes` votes in poll 1 (needed if multiple polls are running)



To stop a poll:
- `/veto` stops the current poll
- `/veto 1` stops poll 1 (needed if multiple polls are running)

Opinions?