### PR TITLE
Fix mirrored and translated regions

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/module/modules/regions/type/modifications/TranslatedRegion.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/regions/type/modifications/TranslatedRegion.java
@@ -1,20 +1,12 @@
 package in.twizmwaz.cardinal.module.modules.regions.type.modifications;
 
-import in.twizmwaz.cardinal.module.ModuleCollection;
+import com.google.common.collect.Lists;
+import in.twizmwaz.cardinal.GameHandler;
 import in.twizmwaz.cardinal.module.modules.regions.RegionModule;
 import in.twizmwaz.cardinal.module.modules.regions.parsers.modifiers.TranslateParser;
 import in.twizmwaz.cardinal.module.modules.regions.type.BlockRegion;
-import in.twizmwaz.cardinal.module.modules.regions.type.CircleRegion;
-import in.twizmwaz.cardinal.module.modules.regions.type.CuboidRegion;
-import in.twizmwaz.cardinal.module.modules.regions.type.CylinderRegion;
-import in.twizmwaz.cardinal.module.modules.regions.type.EmptyRegion;
 import in.twizmwaz.cardinal.module.modules.regions.type.PointRegion;
-import in.twizmwaz.cardinal.module.modules.regions.type.RectangleRegion;
-import in.twizmwaz.cardinal.module.modules.regions.type.SphereRegion;
-import in.twizmwaz.cardinal.module.modules.regions.type.combinations.ComplementRegion;
-import in.twizmwaz.cardinal.module.modules.regions.type.combinations.IntersectRegion;
-import in.twizmwaz.cardinal.module.modules.regions.type.combinations.NegativeRegion;
-import in.twizmwaz.cardinal.module.modules.regions.type.combinations.UnionRegion;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.util.Vector;
 
@@ -23,164 +15,51 @@ import java.util.List;
 public class TranslatedRegion extends RegionModule {
 
     private final Vector offset;
-    private final RegionModule region;
+    private final RegionModule base;
 
     public TranslatedRegion(String name, RegionModule base, Vector offset) {
         super(name);
         this.offset = offset;
-        this.region = translateRegion(base);
-    }
-
-    public TranslatedRegion(String name, RegionModule region) {
-        super(name);
-        this.offset = null;
-        this.region = region;
+        this.base = base;
     }
 
     public TranslatedRegion(TranslateParser parser) {
         this(parser.getName(), parser.getBase(), parser.getOffset());
     }
 
-    public double getXOffset() {
-        return offset.getX();
-    }
-
-    public double getYOffset() {
-        return offset.getY();
-    }
-
-    public double getZOffset() {
-        return offset.getZ();
-    }
-
-    public RegionModule getRegion() {
-        return region;
-    }
-
     @Override
     public boolean contains(Vector vector) {
-        return region.contains(vector);
+        return base.contains(vector.minus(offset));
     }
 
     @Override
     public PointRegion getRandomPoint() {
-        return region.getRandomPoint();
+        return new PointRegion(null, base.getRandomPoint().getVector().plus(offset));
     }
 
     @Override
     public BlockRegion getCenterBlock() {
-        return region.getCenterBlock();
+        return new BlockRegion(null, base.getCenterBlock().getVector().plus(offset));
     }
 
     @Override
     public List<Block> getBlocks() {
-        return region.getBlocks();
+        List<Block> result = Lists.newArrayList();
+        World world = GameHandler.getGameHandler().getMatchWorld();
+        for (Block block : base.getBlocks()) {
+            result.add(block.getLocation().add(offset).toLocation(world).getBlock());
+        }
+        return result;
     }
 
     @Override
     public Vector getMin() {
-        return region.getMin();
+        return base.getMin().plus(offset);
     }
 
     @Override
     public Vector getMax() {
-        return region.getMax();
-    }
-
-    @SuppressWarnings({"unchecked"})
-    private <T extends RegionModule> T translateRegion(T region) {
-
-        double x = getXOffset();
-        double y = getYOffset();
-        double z = getZOffset();
-        if (region instanceof PointRegion) {
-
-            PointRegion rg = (PointRegion) region;
-            return (T) new PointRegion(null, rg.getX() + x, rg.getY() + y, rg.getZ() + z);
-
-        } else if (region instanceof BlockRegion) {
-
-            BlockRegion rg = (BlockRegion) region;
-            return (T) new BlockRegion(null, rg.getX() + x, rg.getY() + y, rg.getZ() + z);
-
-        } else if (region instanceof CircleRegion) {
-
-            CircleRegion rg = (CircleRegion) region;
-            return (T) new CircleRegion(null, rg.getBaseX() + x, rg.getBaseZ() + z, rg.getRadius());
-
-        } else if (region instanceof CylinderRegion) {
-
-            CylinderRegion rg = (CylinderRegion) region;
-            return (T) new CylinderRegion(null, new Vector(rg.getBaseX() + x, rg.getBaseY() + y, rg.getBaseZ() + z), rg.getRadius(), rg.getHeight());
-
-        } else if (region instanceof RectangleRegion) {
-
-            RectangleRegion rg = (RectangleRegion) region;
-            return (T) new RectangleRegion(null, rg.getXMin() + x, rg.getZMin() + z, rg.getXMax() + x, rg.getZMax() + z);
-
-        } else if (region instanceof CuboidRegion) {
-
-            CuboidRegion rg = (CuboidRegion) region;
-            return (T) new CuboidRegion(null, rg.getXMin() + x, rg.getYMin() + y, rg.getZMin() + z, rg.getXMax() + x, rg.getYMax() + y, rg.getZMax() + z);
-
-        } else if (region instanceof SphereRegion) {
-
-            SphereRegion rg = (SphereRegion) region;
-            return (T) new SphereRegion(null, new Vector(rg.getOriginX() + x, rg.getOriginY() + y, rg.getOriginZ() + z), rg.getRadius());
-
-        } else if (region instanceof EmptyRegion) {
-
-            return (T) new EmptyRegion("");
-
-        } else if (region instanceof ComplementRegion) {
-
-            ComplementRegion rg = (ComplementRegion) region;
-            ModuleCollection<RegionModule> regions = new ModuleCollection<>();
-            for (RegionModule rg1 : rg.getRegions()) {
-                regions.add(translateRegion(rg1));
-            }
-            return (T) new ComplementRegion(null, regions);
-
-        } else if (region instanceof IntersectRegion) {
-
-            IntersectRegion rg = (IntersectRegion) region;
-            ModuleCollection<RegionModule> regions = new ModuleCollection<>();
-            for (RegionModule rg1 : rg.getRegions()) {
-                regions.add(translateRegion(rg1));
-            }
-            return (T) new IntersectRegion(null, regions);
-
-        } else if (region instanceof NegativeRegion) {
-
-            NegativeRegion rg = (NegativeRegion) region;
-            ModuleCollection<RegionModule> regions = new ModuleCollection<>();
-            for (RegionModule rg1 : rg.getRegions()) {
-                regions.add(translateRegion(rg1));
-            }
-            return (T) new NegativeRegion(null, regions);
-
-        } else if (region instanceof UnionRegion) {
-
-            UnionRegion rg = (UnionRegion) region;
-            ModuleCollection<RegionModule> regions = new ModuleCollection<>();
-            for (RegionModule rg1 : rg.getRegions()) {
-                regions.add(translateRegion(rg1));
-            }
-            return (T) new UnionRegion(null, regions);
-
-        } else if (region instanceof TranslatedRegion) {
-
-            TranslatedRegion rg = (TranslatedRegion) region;
-            return (T) new TranslatedRegion(null, translateRegion(rg.getRegion()));
-
-        } else if (region instanceof MirroredRegion) {
-
-            MirroredRegion rg = (MirroredRegion) region;
-            return (T) new MirroredRegion(null, translateRegion(rg.getRegion()));
-
-        }
-        return null;
-
+        return base.getMax().plus(offset);
     }
 
 }


### PR DESCRIPTION
mirrored regions in boom box already were working, but dataStation ones weren't for some reason, so i decided to rewrite how mirrored regions are handled, now they work perfectly fine both in boombox and in datastation