### PR TITLE
Allow observers to see players' health on tab

### DIFF
--- a/src/main/resources/settings.yml
+++ b/src/main/resources/settings.yml
@@ -4,6 +4,7 @@ settings:
 - DamageNumbers
 - DeathMessages
 - Elytra
+- Health
 - HighlightDeathMessages
 - JoinMessages
 - Observers
@@ -47,6 +48,13 @@ setting:
     - 'on'
     - off[default]
     description: Equips you with elytra when you are in observer mode
+  Health:
+    values:
+    - 'long'
+    - short[default]
+    - 'tiny'
+    - 'off'
+    description: See health of joined players when you are in observer mode
   HighlightDeathMessages:
     aliases:
     - hdms


### PR DESCRIPTION
There are 4 settings, long (has decimals), short (without decimals), tiny (removes extra characters to shorten it), and off:

- Long:
![image](https://cloud.githubusercontent.com/assets/11789291/17109553/b89578d4-5298-11e6-9ab0-b3fa8358c92d.png)

- Short:
![image](https://cloud.githubusercontent.com/assets/11789291/17109565/cb8b3276-5298-11e6-86cf-84dfa7da1749.png)

- Tiny:
![image](https://cloud.githubusercontent.com/assets/11789291/17109583/dce5d5bc-5298-11e6-843e-30cc17e8aaac.png)

- Off:
![image](https://cloud.githubusercontent.com/assets/11789291/17109593/ebb93c8c-5298-11e6-8489-8998a65bf61b.png)
