### PR TITLE
Fix proximity on completed objectives

### DIFF
--- a/src/main/java/in/twizmwaz/cardinal/command/ProximityCommand.java
+++ b/src/main/java/in/twizmwaz/cardinal/command/ProximityCommand.java
@@ -81,7 +81,7 @@ public class ProximityCommand {
         if (objective instanceof FlagObjective) message += ((FlagObjective) objective).getChatColor();
         message += WordUtils.capitalizeFully(objective.getName().replaceAll("_", " ")) + " ";
         message += objective.isComplete() ? ChatColor.GREEN + "COMPLETE " : objective.isTouched() ? ChatColor.YELLOW + "TOUCHED " : ChatColor.RED + "UNTOUCHED ";
-        if (proximityHandler != null) {
+        if (proximityHandler != null && !objective.isComplete()) {
             message += ChatColor.GRAY + proximityHandler.getProximityName() + ": ";
             message += ChatColor.AQUA + proximityHandler.getProximityAsString();
         }

--- a/src/main/java/in/twizmwaz/cardinal/module/modules/timeLimit/TimeLimit.java
+++ b/src/main/java/in/twizmwaz/cardinal/module/modules/timeLimit/TimeLimit.java
@@ -97,7 +97,7 @@ public class TimeLimit implements Module {
                     List<Double> proximity1 = new ArrayList<Double>(){};
                     List<Double> proximity2 = new ArrayList<Double>(){};
                     for (GameObjective obj : GameHandler.getGameHandler().getMatch().getModules().getModules(GameObjective.class)) {
-                        if (obj.isRequired() && obj.isTouched()){
+                        if (obj.isRequired() && !obj.isComplete() && obj.isTouched()){
                             if (obj instanceof WoolObjective){
                                 if (obj.getTeam().equals(team1)) {
                                     closestCompletion1.add(50);


### PR DESCRIPTION
Exclude completed objectives when calculating the winning team (don't count them twice).

